### PR TITLE
Reject multiallelic VCF records by default

### DIFF
--- a/src/linear_dag/cli.py
+++ b/src/linear_dag/cli.py
@@ -925,7 +925,9 @@ def _main(args):
     compress_p.add_argument("--maf", type=float, help="Filter out variants with MAF less than maf")
     compress_p.add_argument("--remove-indels", action="store_true", help="Should indels be excluded?")
     compress_p.add_argument(
-        "--remove-multiallelics", action="store_true", help="Should multi-allelic sites be excluded?"
+        "--remove-multiallelics",
+        action="store_true",
+        help="Exclude multi-allelic sites instead of raising an error.",
     )
     compress_p.add_argument(
         "--add-individual-nodes", action="store_true", help="Add individual nodes for Hardy Weinberg calculations."
@@ -970,7 +972,11 @@ def _main(args):
         "--maf", type=float, nargs="?", const=None, default=None, help="Filter out variants with MAF < maf"
     )
     step0_p.add_argument("--remove-indels", action="store_true", help="Should indels be excluded?")
-    step0_p.add_argument("--remove-multiallelics", action="store_true", help="Should multi-allelic sites be excluded?")
+    step0_p.add_argument(
+        "--remove-multiallelics",
+        action="store_true",
+        help="Exclude multi-allelic sites instead of raising an error.",
+    )
     step0_p.add_argument(
         "--sex-path",
         nargs="?",

--- a/src/linear_dag/core/lineararg.py
+++ b/src/linear_dag/core/lineararg.py
@@ -74,6 +74,13 @@ class LinearARG(LinearOperator):
     sex: Optional[npt.NDArray[np.int32]] = None  # determines how individual_indices are handled
     # allele_counts: Optional[npt.NDArray[np.int32]] = None
 
+    def __post_init__(self) -> None:
+        # SciPy's LinearOperator namespace checks expect subclasses to define
+        # this attribute. LinearARG exposes shape/dtype as derived properties,
+        # so it cannot call LinearOperator.__init__ directly.
+        reference_operator = aslinearoperator(np.empty((0, 0), dtype=self.A.dtype))
+        self._xp = getattr(reference_operator, "_xp", np)
+
     @cached_property
     def allele_counts(self) -> npt.NDArray[np.int32]:
         """Return per-variant alternate-allele counts across all sample rows.
@@ -281,7 +288,8 @@ class LinearARG(LinearOperator):
         - `logger`: Optional logger for timing/progress output.
         - `maf_filter`: Optional MAF filter applied during VCF parsing.
         - `snps_only`: Whether to remove indels.
-        - `remove_multiallelics`: Whether to remove multi-allelic sites.
+        - `remove_multiallelics`: Whether to exclude multiallelic sites instead
+          of raising an error.
 
         **Returns:**
 
@@ -291,7 +299,8 @@ class LinearARG(LinearOperator):
 
         **Raises:**
 
-        - `ValueError`: If no valid variants are found in the VCF after filtering.
+        - `ValueError`: If no valid variants are found in the VCF after filtering,
+          or if a multiallelic variant is encountered and `remove_multiallelics=False`.
         """
         import time
 

--- a/src/linear_dag/genotype.py
+++ b/src/linear_dag/genotype.py
@@ -49,7 +49,8 @@ def read_vcf(
     - `samples`: Optional sample IDs to include.
     - `maf_filter`: Optional MAF threshold for variant filtering.
     - `remove_indels`: If `True`, skip indel records.
-    - `remove_multiallelics`: If `True`, skip multiallelic variants.
+    - `remove_multiallelics`: If `True`, skip multiallelic variants. If
+      `False`, multiallelic variants raise a `ValueError`.
     - `sex`: Optional sex vector (`0` female / `1` male) for ploidy-aware filtering.
 
     **Returns:**
@@ -63,7 +64,8 @@ def read_vcf(
 
     **Raises:**
 
-    - `ValueError`: If `samples` is provided but none are present in the VCF.
+    - `ValueError`: If `samples` is provided but none are present in the VCF,
+      or if a multiallelic variant is encountered and `remove_multiallelics=False`.
     """
 
     def _update_dict_from_vcf(var: cv.Variant, data: DefaultDict[str, list]) -> DefaultDict[str, list]:
@@ -133,17 +135,27 @@ def read_vcf(
         start = 0
         end = np.inf
 
+    variants = vcf(region) if region else vcf
+
     # TODO: handle missing data
-    for var in vcf(region):
+    for var in variants:
         if (var.POS < start) or (var.POS > end):
             continue  # ignore indels that are outside of region
+
+        if len(var.ALT) > 1:
+            if remove_multiallelics:
+                continue
+            variant_id = var.ID if var.ID is not None else "."
+            raise ValueError(
+                "Multiallelic variant encountered in VCF/BCF input: "
+                f"{var.CHROM}:{var.POS} ID={variant_id} REF={var.REF} ALT={','.join(var.ALT)}. "
+                "Multiallelic variants are not supported by default; use "
+                "`remove_multiallelics=True` or `--remove-multiallelics` to exclude them."
+            )
 
         if remove_indels:
             if any(len(alt) != 1 for alt in var.ALT) or len(var.REF) != 1:
                 continue
-
-        if remove_multiallelics and len(var.ALT) > 1:
-            continue
 
         gts, is_flipped = final_read(var, flip_minor_alleles)
 

--- a/src/linear_dag/pipeline.py
+++ b/src/linear_dag/pipeline.py
@@ -64,7 +64,8 @@ def compress_vcf(
     - `flip_minor_alleles`: Whether to minor-allele flip genotypes while loading.
     - `maf_filter`: Optional MAF filter during VCF loading.
     - `remove_indels`: Whether to remove indel variants.
-    - `remove_multiallelics`: Whether to remove multiallelic sites.
+    - `remove_multiallelics`: Whether to exclude multiallelic sites instead of
+      raising an error.
     - `add_individual_nodes`: Whether to append individual nodes before writing.
 
     **Returns:**
@@ -706,6 +707,8 @@ def make_genotype_matrix(
         Empty regions are represented explicitly by an `is_empty` HDF5 attribute
         and a sentinel metadata text file so downstream steps can skip them
         deterministically.
+
+        Multiallelic variants raise an error unless `remove_multiallelics=True`.
     """
     os.makedirs(f"{out}/logs/", exist_ok=True)
     os.makedirs(f"{out}/variant_metadata/", exist_ok=True)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1344,6 +1344,23 @@ def test_compress_passes_injected_logger_to_pipeline(monkeypatch):
     assert captured["logger"] is injected
 
 
+def test_main_compress_remove_multiallelics_reaches_pipeline(monkeypatch, tmp_path: Path):
+    captured = {}
+
+    def _fake_compress_vcf(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "compress_vcf", _fake_compress_vcf)
+
+    output_h5 = tmp_path / "out.h5"
+    rc = cli._main(["-q", "compress", "input.vcf.gz", str(output_h5), "--remove-multiallelics"])
+
+    assert rc == 0 or rc is None
+    assert captured["input_vcf"] == "input.vcf.gz"
+    assert captured["output_h5"] == str(output_h5)
+    assert captured["remove_multiallelics"] is True
+
+
 def test_step1_passes_injected_logger_to_pipeline(monkeypatch):
     captured = {}
 

--- a/tests/core/test_lineararg.py
+++ b/tests/core/test_lineararg.py
@@ -1,6 +1,9 @@
 import h5py
 import numpy as np
 import polars as pl
+import pytest
+import shutil
+import subprocess
 
 from scipy.sparse import csc_matrix
 
@@ -36,6 +39,52 @@ def test_read_vcf(test_data_dir):
     assert len(flip) == len(v_info)
 
 
+def test_read_vcf_rejects_multiallelic_by_default(test_data_dir):
+    """Test that multiallelic records fail unless explicitly excluded."""
+    vcf_path = test_data_dir / "tiny.ma.vcf.gz"
+
+    with pytest.raises(ValueError, match="Multiallelic variant encountered"):
+        read_vcf(vcf_path)
+
+
+def test_read_vcf_can_exclude_multiallelic_records(test_data_dir):
+    """Test explicit filtering of multiallelic records."""
+    vcf_path = test_data_dir / "tiny.ma.vcf.gz"
+    genotypes, flip, v_info, iids = read_vcf(vcf_path, remove_multiallelics=True)
+
+    assert isinstance(genotypes, csc_matrix)
+    assert isinstance(flip, np.ndarray)
+    assert isinstance(v_info, pl.DataFrame)
+    assert isinstance(iids, list)
+    assert genotypes.shape[1] == len(v_info)
+    assert not v_info["ALT"].str.contains(",").any()
+
+
+def test_read_vcf_rejects_multiallelic_bcf_by_default(test_data_dir, tmp_path):
+    """Test BCF inputs follow the same multiallelic policy as VCF inputs."""
+    if shutil.which("bcftools") is None:
+        pytest.skip("bcftools is required to generate a temporary BCF fixture")
+
+    vcf_path = test_data_dir / "tiny.ma.vcf.gz"
+    bcf_path = tmp_path / "tiny.ma.bcf"
+    subprocess.run(
+        ["bcftools", "view", "-Ob", "-o", str(bcf_path), str(vcf_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with pytest.raises(ValueError, match="Multiallelic variant encountered"):
+        read_vcf(bcf_path)
+
+    genotypes, flip, v_info, iids = read_vcf(bcf_path, remove_multiallelics=True)
+    assert isinstance(genotypes, csc_matrix)
+    assert isinstance(flip, np.ndarray)
+    assert isinstance(v_info, pl.DataFrame)
+    assert isinstance(iids, list)
+    assert not v_info["ALT"].str.contains(",").any()
+
+
 def test_from_vcf(test_data_dir):
     """Test creating a LinearARG from a VCF file."""
     vcf_path = test_data_dir / "1kg_small.vcf"
@@ -49,6 +98,14 @@ def test_from_vcf(test_data_dir):
     assert linarg.shape[1] > 0
     assert linarg.variants is not None
     assert linarg.variants.collect().height > 0
+
+
+def test_from_vcf_rejects_multiallelic_by_default(test_data_dir):
+    """Test that LinearARG construction propagates multiallelic input errors."""
+    vcf_path = test_data_dir / "tiny.ma.vcf.gz"
+
+    with pytest.raises(ValueError, match="Multiallelic variant encountered"):
+        LinearARG.from_vcf(vcf_path)
 
 
 def test_zero_ac_variants():

--- a/tests/test_pipeline_logging.py
+++ b/tests/test_pipeline_logging.py
@@ -61,6 +61,74 @@ def test_msc_step1_skip_paths_log_via_logger_not_stdout(tmp_path: Path, caplog):
     )
 
 
+def test_msc_step0_records_remove_multiallelics_metadata(monkeypatch, tmp_path: Path):
+    vcf_metadata = tmp_path / "vcf_metadata.txt"
+    vcf_metadata.write_text("chr vcf_path\nchr1 input.vcf.gz\n")
+    out_dir = tmp_path / "kodama"
+
+    def _fake_check_output(cmd, shell, text):
+        if "head" in cmd:
+            return "100\n"
+        if "tail" in cmd:
+            return "200\n"
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(pipeline.subprocess, "check_output", _fake_check_output)
+
+    pipeline.msc_step0(
+        vcf_metadata=str(vcf_metadata),
+        large_partition_size=100,
+        n_small_blocks=2,
+        out=str(out_dir),
+        remove_multiallelics=True,
+    )
+
+    metadata = pl.read_parquet_metadata(out_dir / "job_metadata.parquet")
+    assert metadata["remove_multiallelics"] == "True"
+
+
+def test_msc_step1_reads_remove_multiallelics_metadata(monkeypatch, tmp_path: Path):
+    out_dir = tmp_path / "kodama"
+    jobs_metadata = tmp_path / "job_metadata.parquet"
+    pl.DataFrame(
+        {
+            "small_job_id": [0],
+            "large_job_id": [0],
+            "small_region": ["chr1:100-150"],
+            "large_region": ["chr1:100-200"],
+            "vcf_path": ["input.vcf.gz"],
+        }
+    ).write_parquet(
+        jobs_metadata,
+        metadata={
+            "flip_minor_alleles": "False",
+            "keep": "None",
+            "maf": "None",
+            "remove_indels": "False",
+            "remove_multiallelics": "True",
+            "sex_path": "None",
+            "mount_point": "",
+            "out": str(out_dir),
+            "large_partition_size": "100",
+            "n_small_blocks": "2",
+        },
+    )
+
+    captured = {}
+
+    def _fake_make_genotype_matrix(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(pipeline, "make_genotype_matrix", _fake_make_genotype_matrix)
+    monkeypatch.setattr(pipeline, "run_forward_backward", lambda *args, **kwargs: None)
+
+    pipeline.msc_step1(str(jobs_metadata), 0)
+
+    assert captured["vcf_path"] == "input.vcf.gz"
+    assert captured["region"] == "chr1:100-150"
+    assert captured["remove_multiallelics"] is True
+
+
 def test_load_genotypes_does_not_print_progress(tmp_path: Path):
     prefix = tmp_path / "geno"
     np.savetxt(prefix.with_suffix(".txt"), np.array([[0, 1], [1, 0]]), fmt="%d")


### PR DESCRIPTION
## Summary
- Raise a ValueError when read_vcf encounters multiallelic VCF/BCF records unless remove_multiallelics=True is explicitly set.
- Keep --remove-multiallelics as the opt-in filtering path and update CLI/docstring wording.
- Add VCF, generated-BCF, CLI forwarding, and multi-step metadata tests for the policy.
- Add a small LinearOperator namespace compatibility shim needed by current SciPy while preserving LinearARG's derived shape/dtype properties.

## Validation
- uv run pytest tests/core/test_lineararg.py tests/test_pipeline_logging.py tests/cli/test_cli.py tests/test_docstring_admonitions.py -q
- uv run python -m py_compile src/linear_dag/genotype.py src/linear_dag/core/lineararg.py src/linear_dag/pipeline.py src/linear_dag/cli.py tests/core/test_lineararg.py tests/test_pipeline_logging.py tests/cli/test_cli.py
- git diff --check

## Review
- Fresh-context correctness review: no issues found.
- Fresh-context regression/test coverage review: found coverage gaps and private SciPy import concern; addressed by adding CLI/metadata/BCF tests and replacing the private import with a public aslinearoperator-derived namespace.