### PR TITLE
Make compressed edge weights canonical

### DIFF
--- a/benchmarks/benchmark_one_sparse.py
+++ b/benchmarks/benchmark_one_sparse.py
@@ -85,8 +85,9 @@ def summarize_file(path: Path) -> dict:
 
 
 def benchmark_block(path: Path, block: str, repeats: int) -> dict:
-    default = LinearARG.read(path, block=block)
-    compressed = LinearARG.read(path, block=block, compress_edge_weights=True)
+    compressed = LinearARG.read(path, block=block)
+    default = compressed.copy()
+    default.A = compressed.A.to_csc()
     rng = np.random.default_rng(20260713)
     cases = {
         "matvec": (default._matvec, compressed._matvec, rng.standard_normal(default.shape[1])),

--- a/benchmarks/benchmark_one_sparse.py
+++ b/benchmarks/benchmark_one_sparse.py
@@ -1,0 +1,166 @@
+"""Benchmark default-one edge-weight compression on HDF5 LinearARG blocks."""
+
+import argparse
+import json
+import time
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from linear_dag.core.lineararg import LinearARG
+
+
+def _core_nbytes(linarg: LinearARG) -> int:
+    adjacency = linarg.A
+    if hasattr(adjacency, "nbytes"):
+        adjacency_nbytes = adjacency.nbytes
+    else:
+        adjacency_nbytes = adjacency.indptr.nbytes + adjacency.indices.nbytes + adjacency.data.nbytes
+    return adjacency_nbytes + sum(
+        array.nbytes
+        for array in (linarg.variant_indices, linarg.flip, linarg.nonunique_indices)
+        if array is not None
+    )
+
+
+def _median_runtime(default_fn, compressed_fn, argument, repeats: int) -> tuple[float, float]:
+    timings = {"default": [], "compressed": []}
+    default_fn(argument)
+    compressed_fn(argument)
+    for iteration in range(2 * repeats):
+        key = "default" if iteration % 2 == 0 else "compressed"
+        start = time.perf_counter()
+        (default_fn if key == "default" else compressed_fn)(argument)
+        timings[key].append(time.perf_counter() - start)
+    return float(np.median(timings["default"])), float(np.median(timings["compressed"]))
+
+
+def _select_blocks(path: Path, count: int) -> list[str]:
+    with h5py.File(path, "r") as file:
+        blocks = [(name, int(obj.attrs["n_entries"])) for name, obj in file.items() if isinstance(obj, h5py.Group)]
+    blocks.sort(key=lambda item: item[1])
+    indices = np.linspace(0, len(blocks) - 1, min(count, len(blocks))).round().astype(int)
+    return [blocks[index][0] for index in np.unique(indices)]
+
+
+def summarize_file(path: Path) -> dict:
+    edges = ones = minus_ones = other = core_bytes = 0
+    groups = 0
+    with h5py.File(path, "r") as file:
+        for group in (obj for obj in file.values() if isinstance(obj, h5py.Group)):
+            if "data" not in group:
+                continue
+            data = group["data"][:]
+            groups += 1
+            edges += data.size
+            ones += int(np.count_nonzero(data == 1))
+            minus_ones += int(np.count_nonzero(data == -1))
+            other += int(np.count_nonzero((data != 1) & (data != -1)))
+            core_bytes += sum(
+                dataset.size * dataset.dtype.itemsize
+                for name, dataset in group.items()
+                if isinstance(dataset, h5py.Dataset)
+                and name in {"data", "indices", "indptr", "nonunique_indices", "variant_indices", "flip"}
+            )
+    nonunit = edges - ones
+    dense_weight_bytes = 4 * edges
+    compressed_weight_bytes = 8 * nonunit
+    compressed_core_bytes = core_bytes - dense_weight_bytes + compressed_weight_bytes
+    return {
+        "path": str(path),
+        "groups": groups,
+        "edges": edges,
+        "fraction_one": ones / edges,
+        "fraction_minus_one": minus_ones / edges,
+        "fraction_other": other / edges,
+        "dense_weight_bytes": dense_weight_bytes,
+        "compressed_weight_bytes": compressed_weight_bytes,
+        "weight_memory_ratio": compressed_weight_bytes / dense_weight_bytes,
+        "core_bytes": core_bytes,
+        "compressed_core_bytes": compressed_core_bytes,
+        "core_memory_ratio": compressed_core_bytes / core_bytes,
+    }
+
+
+def benchmark_block(path: Path, block: str, repeats: int) -> dict:
+    default = LinearARG.read(path, block=block)
+    compressed = LinearARG.read(path, block=block, compress_edge_weights=True)
+    rng = np.random.default_rng(20260713)
+    cases = {
+        "matvec": (default._matvec, compressed._matvec, rng.standard_normal(default.shape[1])),
+        "rmatvec": (default._rmatvec, compressed._rmatvec, rng.standard_normal(default.shape[0])),
+        "matmat_8": (
+            default._matmat,
+            compressed._matmat,
+            rng.standard_normal((default.shape[1], 8)).astype(np.float32),
+        ),
+        "rmatmat_8": (
+            default._rmatmat,
+            compressed._rmatmat,
+            rng.standard_normal((default.shape[0], 8)).astype(np.float32),
+        ),
+        "matmat_32": (
+            default._matmat,
+            compressed._matmat,
+            rng.standard_normal((default.shape[1], 32)).astype(np.float32),
+        ),
+        "rmatmat_32": (
+            default._rmatmat,
+            compressed._rmatmat,
+            rng.standard_normal((default.shape[0], 32)).astype(np.float32),
+        ),
+    }
+    timings = {}
+    for name, (default_fn, compressed_fn, argument) in cases.items():
+        default_result = default_fn(argument)
+        compressed_result = compressed_fn(argument)
+        default_seconds, compressed_seconds = _median_runtime(default_fn, compressed_fn, argument, repeats)
+        timings[name] = {
+            "default_seconds": default_seconds,
+            "compressed_seconds": compressed_seconds,
+            "runtime_ratio": compressed_seconds / default_seconds,
+            "max_absolute_error": float(np.max(np.abs(default_result - compressed_result))),
+        }
+    default_bytes = _core_nbytes(default)
+    compressed_bytes = _core_nbytes(compressed)
+    return {
+        "path": str(path),
+        "block": block,
+        "nodes": int(default.A.shape[0]),
+        "edges": int(default.A.nnz),
+        "variants": int(default.shape[1]),
+        "default_core_bytes": default_bytes,
+        "compressed_core_bytes": compressed_bytes,
+        "core_memory_ratio": compressed_bytes / default_bytes,
+        "timings": timings,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument("--blocks-per-file", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    result = {
+        "files": [summarize_file(path) for path in args.paths],
+        "blocks": [
+            benchmark_block(path, block, args.repeats)
+            for path in args.paths
+            for block in _select_blocks(path, args.blocks_per_file)
+        ],
+    }
+    text = json.dumps(result, indent=2)
+    if args.output is None:
+        print(text)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/results/one_sparse_1kg_1mb_2026-07-13.json
+++ b/benchmarks/results/one_sparse_1kg_1mb_2026-07-13.json
@@ -1,0 +1,260 @@
+{
+  "files": [
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/javier/1kg_blocksize_1Mb.h5",
+      "groups": 674,
+      "edges": 205315586,
+      "fraction_one": 0.9825722290756825,
+      "fraction_minus_one": 0.016699005013676847,
+      "fraction_other": 0.0007287659106406077,
+      "dense_weight_bytes": 821262344,
+      "compressed_weight_bytes": 28625544,
+      "weight_memory_ratio": 0.03485554184863491,
+      "core_bytes": 2198519407,
+      "compressed_core_bytes": 1405882607,
+      "core_memory_ratio": 0.6394679085041163
+    }
+  ],
+  "blocks": [
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/javier/1kg_blocksize_1Mb.h5",
+      "block": "3_92000001_93000000",
+      "nodes": 12772,
+      "edges": 40967,
+      "variants": 1931,
+      "default_core_bytes": 439571,
+      "compressed_core_bytes": 275783,
+      "core_memory_ratio": 0.6273912519251725,
+      "timings": {
+        "matvec": {
+          "default_seconds": 5.070853512734175e-05,
+          "compressed_seconds": 4.554097540676594e-05,
+          "runtime_ratio": 0.898092900778956,
+          "max_absolute_error": 0.0
+        },
+        "rmatvec": {
+          "default_seconds": 4.699951387010515e-05,
+          "compressed_seconds": 4.7250010538846254e-05,
+          "runtime_ratio": 1.005329771483029,
+          "max_absolute_error": 7.105427357601002e-15
+        },
+        "matmat_8": {
+          "default_seconds": 0.0003419994900468737,
+          "compressed_seconds": 0.00034225001581944525,
+          "runtime_ratio": 1.0007325325910201,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_8": {
+          "default_seconds": 0.00034791696816682816,
+          "compressed_seconds": 0.00035295795532874763,
+          "runtime_ratio": 1.0144890523405063,
+          "max_absolute_error": 0.0
+        },
+        "matmat_32": {
+          "default_seconds": 0.0004466454847715795,
+          "compressed_seconds": 0.0004229375335853547,
+          "runtime_ratio": 0.9469199801754419,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_32": {
+          "default_seconds": 0.00039545801701024175,
+          "compressed_seconds": 0.00037852051900699735,
+          "runtime_ratio": 0.9571699212692766,
+          "max_absolute_error": 0.0
+        }
+      }
+    },
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/javier/1kg_blocksize_1Mb.h5",
+      "block": "3_163000001_164000000",
+      "nodes": 75540,
+      "edges": 252433,
+      "variants": 25033,
+      "default_core_bytes": 2748953,
+      "compressed_core_bytes": 1801965,
+      "core_memory_ratio": 0.655509570370974,
+      "timings": {
+        "matvec": {
+          "default_seconds": 0.0005455625068861991,
+          "compressed_seconds": 0.000542416499229148,
+          "runtime_ratio": 0.994233460662451,
+          "max_absolute_error": 2.842170943040401e-14
+        },
+        "rmatvec": {
+          "default_seconds": 0.0005035625072196126,
+          "compressed_seconds": 0.0005071459745522588,
+          "runtime_ratio": 1.007116231413717,
+          "max_absolute_error": 1.8474111129762605e-13
+        },
+        "matmat_8": {
+          "default_seconds": 0.0021449169726110995,
+          "compressed_seconds": 0.0021762505057267845,
+          "runtime_ratio": 1.0146082731946222,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_8": {
+          "default_seconds": 0.00202266700216569,
+          "compressed_seconds": 0.002043104002950713,
+          "runtime_ratio": 1.010103986846644,
+          "max_absolute_error": 0.0
+        },
+        "matmat_32": {
+          "default_seconds": 0.0030130830127745867,
+          "compressed_seconds": 0.0029129795148037374,
+          "runtime_ratio": 0.9667770527574449,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_32": {
+          "default_seconds": 0.002297645987709984,
+          "compressed_seconds": 0.002247750002425164,
+          "runtime_ratio": 0.9782838672486049,
+          "max_absolute_error": 0.0
+        }
+      }
+    },
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/javier/1kg_blocksize_1Mb.h5",
+      "block": "3_155000001_156000000",
+      "nodes": 84513,
+      "edges": 289130,
+      "variants": 23660,
+      "default_core_bytes": 3107448,
+      "compressed_core_bytes": 1989592,
+      "core_memory_ratio": 0.6402655812744091,
+      "timings": {
+        "matvec": {
+          "default_seconds": 0.0006478750146925449,
+          "compressed_seconds": 0.0006368750182446092,
+          "runtime_ratio": 0.9830214220359218,
+          "max_absolute_error": 2.842170943040401e-14
+        },
+        "rmatvec": {
+          "default_seconds": 0.0005571664951276034,
+          "compressed_seconds": 0.0005506875168066472,
+          "runtime_ratio": 0.988371557913811,
+          "max_absolute_error": 8.526512829121202e-14
+        },
+        "matmat_8": {
+          "default_seconds": 0.0023967080051079392,
+          "compressed_seconds": 0.002373875002376735,
+          "runtime_ratio": 0.9904731812625728,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_8": {
+          "default_seconds": 0.0022411665122490376,
+          "compressed_seconds": 0.0022694584913551807,
+          "runtime_ratio": 1.0126237738032913,
+          "max_absolute_error": 0.0
+        },
+        "matmat_32": {
+          "default_seconds": 0.0032678125135134906,
+          "compressed_seconds": 0.0031369790085591376,
+          "runtime_ratio": 0.9599629708212105,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_32": {
+          "default_seconds": 0.0025396670098416507,
+          "compressed_seconds": 0.0025331039796583354,
+          "runtime_ratio": 0.9974157910632053,
+          "max_absolute_error": 0.0
+        }
+      }
+    },
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/javier/1kg_blocksize_1Mb.h5",
+      "block": "2_70000001_71000000",
+      "nodes": 98157,
+      "edges": 335440,
+      "variants": 26334,
+      "default_core_bytes": 3600450,
+      "compressed_core_bytes": 2302746,
+      "core_memory_ratio": 0.6395717202016414,
+      "timings": {
+        "matvec": {
+          "default_seconds": 0.0007074580062180758,
+          "compressed_seconds": 0.0006846045143902302,
+          "runtime_ratio": 0.9676963273763547,
+          "max_absolute_error": 2.842170943040401e-14
+        },
+        "rmatvec": {
+          "default_seconds": 0.0006312495097517967,
+          "compressed_seconds": 0.0006335624784696847,
+          "runtime_ratio": 1.0036641117056826,
+          "max_absolute_error": 4.263256414560601e-14
+        },
+        "matmat_8": {
+          "default_seconds": 0.002681624988326803,
+          "compressed_seconds": 0.00263229149277322,
+          "runtime_ratio": 0.9816031340070542,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_8": {
+          "default_seconds": 0.0025948545371647924,
+          "compressed_seconds": 0.002599520987132564,
+          "runtime_ratio": 1.0017983474221528,
+          "max_absolute_error": 0.0
+        },
+        "matmat_32": {
+          "default_seconds": 0.0036581039894372225,
+          "compressed_seconds": 0.0036081040161661804,
+          "runtime_ratio": 0.9863317244628865,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_32": {
+          "default_seconds": 0.002990125532960519,
+          "compressed_seconds": 0.002894041535910219,
+          "runtime_ratio": 0.9678662330423407,
+          "max_absolute_error": 0.0
+        }
+      }
+    },
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/javier/1kg_blocksize_1Mb.h5",
+      "block": "1_123000001_124000000",
+      "nodes": 178119,
+      "edges": 1285979,
+      "variants": 67182,
+      "default_core_bytes": 12048698,
+      "compressed_core_bytes": 6904910,
+      "core_memory_ratio": 0.5730834983165816,
+      "timings": {
+        "matvec": {
+          "default_seconds": 0.0014505000144708902,
+          "compressed_seconds": 0.0014340210473164916,
+          "runtime_ratio": 0.9886391127266485,
+          "max_absolute_error": 0.0
+        },
+        "rmatvec": {
+          "default_seconds": 0.0014092499914113432,
+          "compressed_seconds": 0.0013374370173551142,
+          "runtime_ratio": 0.9490417069406477,
+          "max_absolute_error": 1.4210854715202004e-14
+        },
+        "matmat_8": {
+          "default_seconds": 0.008358104503713548,
+          "compressed_seconds": 0.008271104539744556,
+          "runtime_ratio": 0.989590945658751,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_8": {
+          "default_seconds": 0.00784406196908094,
+          "compressed_seconds": 0.0077605209662579,
+          "runtime_ratio": 0.9893497778125243,
+          "max_absolute_error": 0.0
+        },
+        "matmat_32": {
+          "default_seconds": 0.011293187504634261,
+          "compressed_seconds": 0.010582646005786955,
+          "runtime_ratio": 0.9370822897826031,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_32": {
+          "default_seconds": 0.009643750003306195,
+          "compressed_seconds": 0.008679811988258734,
+          "runtime_ratio": 0.9000453127966828,
+          "max_absolute_error": 0.0
+        }
+      }
+    }
+  ]
+}

--- a/benchmarks/results/one_sparse_1kg_2026-07-13.json
+++ b/benchmarks/results/one_sparse_1kg_2026-07-13.json
@@ -1,0 +1,274 @@
+{
+  "files": [
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/javier/1kg_blocksize_20Mb.h5",
+      "groups": 36,
+      "edges": 203521903,
+      "fraction_one": 0.9818097514546137,
+      "fraction_minus_one": 0.017399065888254787,
+      "fraction_other": 0.0007911826571315029,
+      "dense_weight_bytes": 814087612,
+      "compressed_weight_bytes": 29616912,
+      "weight_memory_ratio": 0.03638049709077258,
+      "core_bytes": 2145472359,
+      "compressed_core_bytes": 1361001659,
+      "core_memory_ratio": 0.6343599130003986
+    },
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/test/1kg_chromosomes_n50.h5",
+      "groups": 2,
+      "edges": 2121633,
+      "fraction_one": 0.8811651213946993,
+      "fraction_minus_one": 0.10327610854469176,
+      "fraction_other": 0.015558770060608974,
+      "dense_weight_bytes": 8486532,
+      "compressed_weight_bytes": 2016992,
+      "weight_memory_ratio": 0.23766975721060146,
+      "core_bytes": 98094101,
+      "compressed_core_bytes": 91624561,
+      "core_memory_ratio": 0.9340476141373679
+    }
+  ],
+  "blocks": [
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/javier/1kg_blocksize_20Mb.h5",
+      "block": "2_240000001_260000000",
+      "nodes": 253410,
+      "edges": 949449,
+      "variants": 64918,
+      "default_core_bytes": 9947466,
+      "compressed_core_bytes": 6238046,
+      "core_memory_ratio": 0.6270990018965634,
+      "timings": {
+        "matvec": {
+          "default_seconds": 0.0021244999952614307,
+          "compressed_seconds": 0.0019482499919831753,
+          "runtime_ratio": 0.9170393016373874,
+          "max_absolute_error": 5.684341886080802e-14
+        },
+        "rmatvec": {
+          "default_seconds": 0.001797459030058235,
+          "compressed_seconds": 0.0017025000415742397,
+          "runtime_ratio": 0.9471704295363446,
+          "max_absolute_error": 9.947598300641403e-14
+        },
+        "matmat_8": {
+          "default_seconds": 0.007336915994528681,
+          "compressed_seconds": 0.007082625001203269,
+          "runtime_ratio": 0.965340887981402,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_8": {
+          "default_seconds": 0.006959166028536856,
+          "compressed_seconds": 0.006938540958799422,
+          "runtime_ratio": 0.9970362727871617,
+          "max_absolute_error": 0.0
+        },
+        "matmat_32": {
+          "default_seconds": 0.01043725002091378,
+          "compressed_seconds": 0.009908333013299853,
+          "runtime_ratio": 0.94932410294339,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_32": {
+          "default_seconds": 0.008109749993309379,
+          "compressed_seconds": 0.007804332999512553,
+          "runtime_ratio": 0.9623395303124267,
+          "max_absolute_error": 0.0
+        }
+      }
+    },
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/javier/1kg_blocksize_20Mb.h5",
+      "block": "1_40000001_60000000",
+      "nodes": 1502793,
+      "edges": 5551766,
+      "variants": 472152,
+      "default_core_bytes": 58797236,
+      "compressed_core_bytes": 37414148,
+      "core_memory_ratio": 0.6363249456147905,
+      "timings": {
+        "matvec": {
+          "default_seconds": 0.013034000003244728,
+          "compressed_seconds": 0.012418625003192574,
+          "runtime_ratio": 0.952786941852159,
+          "max_absolute_error": 2.8421709430404007e-13
+        },
+        "rmatvec": {
+          "default_seconds": 0.010959999985061586,
+          "compressed_seconds": 0.010902917012572289,
+          "runtime_ratio": 0.9947916995832937,
+          "max_absolute_error": 1.4210854715202004e-13
+        },
+        "matmat_8": {
+          "default_seconds": 0.04812229098752141,
+          "compressed_seconds": 0.047037667012773454,
+          "runtime_ratio": 0.9774610902247108,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_8": {
+          "default_seconds": 0.0420090839616023,
+          "compressed_seconds": 0.04246174998115748,
+          "runtime_ratio": 1.0107754318082474,
+          "max_absolute_error": 0.0
+        },
+        "matmat_32": {
+          "default_seconds": 0.06658020801842213,
+          "compressed_seconds": 0.06483491696417332,
+          "runtime_ratio": 0.9737866386093912,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_32": {
+          "default_seconds": 0.04931979102548212,
+          "compressed_seconds": 0.047576333046890795,
+          "runtime_ratio": 0.964649931754769,
+          "max_absolute_error": 0.0
+        }
+      }
+    },
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/javier/1kg_blocksize_20Mb.h5",
+      "block": "1_1_20000000",
+      "nodes": 2206021,
+      "edges": 8666744,
+      "variants": 569305,
+      "default_core_bytes": 89828649,
+      "compressed_core_bytes": 55971681,
+      "core_memory_ratio": 0.6230938750954609,
+      "timings": {
+        "matvec": {
+          "default_seconds": 0.01883145800093189,
+          "compressed_seconds": 0.01838695799233392,
+          "runtime_ratio": 0.9763958792475881,
+          "max_absolute_error": 3.410605131648481e-13
+        },
+        "rmatvec": {
+          "default_seconds": 0.016118832980282605,
+          "compressed_seconds": 0.015885166998486966,
+          "runtime_ratio": 0.9855035422178844,
+          "max_absolute_error": 1.8474111129762605e-13
+        },
+        "matmat_8": {
+          "default_seconds": 0.06982404104201123,
+          "compressed_seconds": 0.06677858298644423,
+          "runtime_ratio": 0.9563838183794802,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_8": {
+          "default_seconds": 0.062449541001114994,
+          "compressed_seconds": 0.0627461249823682,
+          "runtime_ratio": 1.0047491779202655,
+          "max_absolute_error": 0.0
+        },
+        "matmat_32": {
+          "default_seconds": 0.09367116703651845,
+          "compressed_seconds": 0.0892209589947015,
+          "runtime_ratio": 0.9524911647563652,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_32": {
+          "default_seconds": 0.07365070900414139,
+          "compressed_seconds": 0.07017920800717548,
+          "runtime_ratio": 0.9528653417746363,
+          "max_absolute_error": 0.0
+        }
+      }
+    },
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/test/1kg_chromosomes_n50.h5",
+      "block": "22_0_999999999",
+      "nodes": 933043,
+      "edges": 384455,
+      "variants": 1066557,
+      "default_core_bytes": 15872773,
+      "compressed_core_bytes": 14671065,
+      "core_memory_ratio": 0.9242912375802262,
+      "timings": {
+        "matvec": {
+          "default_seconds": 0.0043670000159181654,
+          "compressed_seconds": 0.0047894580056890845,
+          "runtime_ratio": 1.0967387195399625,
+          "max_absolute_error": 9.094947017729282e-13
+        },
+        "rmatvec": {
+          "default_seconds": 0.0032690829830244184,
+          "compressed_seconds": 0.0035427080001682043,
+          "runtime_ratio": 1.08370084778045,
+          "max_absolute_error": 2.4868995751603507e-14
+        },
+        "matmat_8": {
+          "default_seconds": 0.017801749985665083,
+          "compressed_seconds": 0.017823749978560954,
+          "runtime_ratio": 1.0012358331576159,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_8": {
+          "default_seconds": 0.013549708994105458,
+          "compressed_seconds": 0.014166167005896568,
+          "runtime_ratio": 1.0454960333140209,
+          "max_absolute_error": 0.0
+        },
+        "matmat_32": {
+          "default_seconds": 0.0465881249983795,
+          "compressed_seconds": 0.04705133294919506,
+          "runtime_ratio": 1.009942618442611,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_32": {
+          "default_seconds": 0.016482874983921647,
+          "compressed_seconds": 0.017668082960881293,
+          "runtime_ratio": 1.0719054156581158,
+          "max_absolute_error": 0.0
+        }
+      }
+    },
+    {
+      "path": "/Users/lukeoconnor/Dropbox/GitHub/linear-dag/data/test/1kg_chromosomes_n50.h5",
+      "block": "1_0_999999999",
+      "nodes": 4941075,
+      "edges": 1737178,
+      "variants": 5759060,
+      "default_core_bytes": 82221328,
+      "compressed_core_bytes": 76953496,
+      "core_memory_ratio": 0.9359310761801366,
+      "timings": {
+        "matvec": {
+          "default_seconds": 0.023423791979439557,
+          "compressed_seconds": 0.025379166996572167,
+          "runtime_ratio": 1.0834781583976223,
+          "max_absolute_error": 4.547473508864641e-12
+        },
+        "rmatvec": {
+          "default_seconds": 0.017966084007639438,
+          "compressed_seconds": 0.019351791008375585,
+          "runtime_ratio": 1.0771290505013182,
+          "max_absolute_error": 3.019806626980426e-14
+        },
+        "matmat_8": {
+          "default_seconds": 0.09405825001886114,
+          "compressed_seconds": 0.09402795799542218,
+          "runtime_ratio": 0.9996779440034991,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_8": {
+          "default_seconds": 0.07179020799230784,
+          "compressed_seconds": 0.07688800001051277,
+          "runtime_ratio": 1.0710095730430416,
+          "max_absolute_error": 0.0
+        },
+        "matmat_32": {
+          "default_seconds": 0.25280799996107817,
+          "compressed_seconds": 0.25219804199878126,
+          "runtime_ratio": 0.9975872679567466,
+          "max_absolute_error": 0.0
+        },
+        "rmatmat_32": {
+          "default_seconds": 0.0894176249857992,
+          "compressed_seconds": 0.09447474998887628,
+          "runtime_ratio": 1.0565562438487963,
+          "max_absolute_error": 0.0
+        }
+      }
+    }
+  ]
+}

--- a/docs/one_sparse_edge_weights.md
+++ b/docs/one_sparse_edge_weights.md
@@ -73,7 +73,7 @@ Topology-changing operations materialize SciPy matrices only at their local boun
 
 ### On-disk effect
 
-The legacy HDF5 schema stores `indptr`, `indices`, and `data`. The default compressed schema stores:
+The default HDF5 schema remains the legacy-compatible `indptr`, `indices`, and `data` layout so files written by upgraded code remain readable by existing installations. An explicit compressed schema stores:
 
 ```text
 indptr
@@ -88,7 +88,7 @@ and sets the group attribute:
 edge_weight_encoding = "one_sparse_v1"
 ```
 
-The `data` dataset is omitted. Existing HDF5 files remain readable and are converted directly to compressed in-memory adjacency. Passing `compress_edge_weights=False` to `write()` or `write_blosc()` emits the legacy schema for consumers that have not been upgraded. Within new code, `linarg.A.to_csc()` provides the equivalent SciPy representation without changing the canonical stored form.
+The `data` dataset is omitted from the explicit compressed schema. Existing HDF5 files remain readable and are converted directly to compressed in-memory adjacency. Passing `compress_edge_weights=True` to `write()` or `write_blosc()` opts into compressed storage when all consumers understand `one_sparse_v1`; the default continues to emit `data`. Within new code, `linarg.A.to_csc()` provides the equivalent mutable SciPy representation without changing the canonical stored form.
 
 The on-disk reduction is much smaller than the in-memory reduction because HDF5 gzip compression already encodes a long, repetitive integer array efficiently. On three representative 20 Mb blocks, the optional format reduced total serialized size by 1.6%, 2.4%, and 1.9%. The main benefit is therefore resident memory, particularly when several blocks are loaded by parallel workers, rather than disk capacity.
 

--- a/docs/one_sparse_edge_weights.md
+++ b/docs/one_sparse_edge_weights.md
@@ -6,7 +6,7 @@ The LinearARG adjacency matrix is stored in compressed sparse column (CSC) forma
 
 For the full 3,202-sample 1000 Genomes LinearARGs on the test computer, this representation reduced the memory used by edge weights by approximately 96.5% and reduced the memory used by the core graph arrays by 36–37%. Forward matrix-vector multiplication was consistently faster, while reverse matrix-vector multiplication was approximately unchanged or faster. Matrix-matrix multiplication was generally unchanged for narrow matrices and faster for wider matrices.
 
-The approach is not universally beneficial. A sample-thinned 50-haplotype LinearARG contained many more non-unit edges and obtained little memory benefit while becoming slower. The compressed representation should therefore be used for graphs whose edge weights are strongly dominated by ones rather than enabled unconditionally.
+The approach is not universally beneficial. A sample-thinned 50-haplotype LinearARG contained many more non-unit edges and obtained little memory benefit while becoming slower. The implementation nevertheless uses compressed weights as the canonical in-memory representation so that loading behavior and memory use are predictable. Callers that require SciPy sparse-matrix operations can materialize a CSC adapter explicitly.
 
 ## Task
 
@@ -62,17 +62,18 @@ For the 20 Mb 1000 Genomes file, $K/E = 0.01819$, so the compressed weights occu
 
 “Core graph” includes the CSC topology, edge weights, variant indices, flip flags, and non-unique workspace mapping. It excludes variant strings and other optional metadata that are not required for algebra-only loading.
 
-The implementation is opt-in:
+The compressed representation is the default for all LinearARG construction and loading paths:
 
 ```python
-linarg = LinearARG.read(path, block=block, compress_edge_weights=True)
+linarg = LinearARG.read(path, block=block)
+scipy_adjacency = linarg.A.to_csc()
 ```
 
-The default loading path still constructs the existing SciPy CSC matrix.
+Topology-changing operations materialize SciPy matrices only at their local boundaries and recompress their results. Parallel workers therefore retain compressed weights for the lifetime of each loaded block.
 
 ### On-disk effect
 
-The existing HDF5 schema stores `indptr`, `indices`, and `data`. The optional compressed schema stores:
+The legacy HDF5 schema stores `indptr`, `indices`, and `data`. The default compressed schema stores:
 
 ```text
 indptr
@@ -87,7 +88,7 @@ and sets the group attribute:
 edge_weight_encoding = "one_sparse_v1"
 ```
 
-The `data` dataset is omitted. Readers can either retain the compressed representation or reconstruct an ordinary CSC `data` array. Existing HDF5 files remain readable, and uncompressed writing remains the default.
+The `data` dataset is omitted. Existing HDF5 files remain readable and are converted directly to compressed in-memory adjacency. Passing `compress_edge_weights=False` to `write()` or `write_blosc()` emits the legacy schema for consumers that have not been upgraded. Within new code, `linarg.A.to_csc()` provides the equivalent SciPy representation without changing the canonical stored form.
 
 The on-disk reduction is much smaller than the in-memory reduction because HDF5 gzip compression already encodes a long, repetitive integer array efficiently. On three representative 20 Mb blocks, the optional format reduced total serialized size by 1.6%, 2.4%, and 1.9%. The main benefit is therefore resident memory, particularly when several blocks are loaded by parallel workers, rather than disk capacity.
 
@@ -199,13 +200,13 @@ The 50-haplotype chromosome file had a different distribution:
 
 Compressed weights occupied 23.8% of the original weight memory, but topology and workspace arrays dominated the graph. Total core memory fell by only 6.6%, while matrix-vector multiplication slowed by approximately 8–10%.
 
-This graph does not contain individual nodes, so the result demonstrates that the relevant selection criterion is the actual non-unit edge fraction and graph structure, not only the presence or absence of individual nodes. A production default should inspect the projected memory ratio, and potentially an edge-to-node measure, before selecting the compressed representation.
+This graph does not contain individual nodes, so the result demonstrates that the performance tradeoff depends on the actual non-unit edge fraction and graph structure, not only the presence or absence of individual nodes. Workloads dominated by such graphs should measure the canonical representation against a locally materialized SciPy alternative.
 
 ## Conclusions
 
 Implicitly storing the common edge weight is effective for full-cohort 1000 Genomes LinearARGs. The selected representation reduces core graph memory by roughly 36–37% while preserving or improving the cost of the primary forward matrix-vector operation. The solver changes are important: a naive sparse lookup or second BLAS pass can give back the computational benefit, whereas column-local corrections for matvec and run-segmented traversal for matmat exploit the CSC ordering efficiently.
 
-The representation should remain optional or be selected adaptively. It is highly favorable when approximately 98% of edges have weight one, but it is not favorable for every LinearARG construction.
+The representation is most favorable when approximately 98% of edges have weight one, but it is not faster for every LinearARG construction. It is used canonically to provide consistent memory behavior across serial and parallel loading, while explicit SciPy adapters preserve operations that require the standard sparse-matrix API.
 
 ## Reproducing the analysis
 

--- a/docs/one_sparse_edge_weights.md
+++ b/docs/one_sparse_edge_weights.md
@@ -1,0 +1,212 @@
+# Compressing edge weights in LinearARGs
+
+## Summary
+
+The LinearARG adjacency matrix is stored in compressed sparse column (CSC) format. Its edge-weight array uses one 32-bit integer per edge, even though nearly all edge weights in full 1000 Genomes LinearARGs are equal to one. We evaluated replacing this dense weight array with a sparse list of the edges whose weights are not one.
+
+For the full 3,202-sample 1000 Genomes LinearARGs on the test computer, this representation reduced the memory used by edge weights by approximately 96.5% and reduced the memory used by the core graph arrays by 36–37%. Forward matrix-vector multiplication was consistently faster, while reverse matrix-vector multiplication was approximately unchanged or faster. Matrix-matrix multiplication was generally unchanged for narrow matrices and faster for wider matrices.
+
+The approach is not universally beneficial. A sample-thinned 50-haplotype LinearARG contained many more non-unit edges and obtained little memory benefit while becoming slower. The compressed representation should therefore be used for graphs whose edge weights are strongly dominated by ones rather than enabled unconditionally.
+
+## Task
+
+The goal was to determine whether the LinearARG could avoid storing a dense edge-weight array without increasing the cost of its principal algebraic operations. The work had four parts:
+
+1. Locate representative 1000 Genomes LinearARGs and characterize their edge-weight distributions.
+2. Design an in-memory representation that stores the common value, one, implicitly.
+3. Modify the forward and reverse triangular solvers used by LinearARG matrix-vector and matrix-matrix multiplication.
+4. Compare numerical correctness, memory use, and runtime with the existing representation.
+
+LinearARGs containing explicit individual nodes were not used for the primary benchmarks. These nodes can increase the fraction of non-unit edges and could make this compression less favorable.
+
+## Existing representation
+
+Let $A$ be the square, lower-triangular adjacency matrix underlying a LinearARG. In CSC format, its principal arrays are:
+
+- `indptr`: offsets marking the start and end of each source-node column;
+- `indices`: the destination node of each edge; and
+- `data`: the integer weight of each edge.
+
+If the graph has $N$ nodes and $E$ edges, the topology requires approximately $4(N+1) + 4E$ bytes for `indptr` and `indices`, and the edge weights require another $4E$ bytes. Other LinearARG arrays store variant-node indices, allele flips, and the non-unique workspace mapping used by matrix-matrix operations.
+
+The whole-genome 1000 Genomes files contained about 204–205 million edges. The edge-weight distribution was:
+
+| Block layout | Edges | Weight $+1$ | Weight $-1$ | Other weights |
+|---|---:|---:|---:|---:|
+| 20 Mb blocks | 203,521,903 | 98.1810% | 1.7399% | 0.0791% |
+| 1 Mb blocks | 205,315,586 | 98.2572% | 1.6699% | 0.0729% |
+
+Thus, the dense `data` array spends almost all of its memory repeatedly storing the value one.
+
+## Compressed representation
+
+The new `OneSparseMatrix` retains the CSC topology but replaces `data` with:
+
+- `nonunit_edge_indices`: positions in `indices` whose logical weight is not one; and
+- `nonunit_values`: the corresponding integer weights.
+
+All edges not listed in `nonunit_edge_indices` have an implicit weight of one. If $K$ of the $E$ edges are non-unit, the weight representation changes from $4E$ bytes to $8K$ bytes. Its size relative to the original weight array is therefore
+
+$$
+\frac{8K}{4E} = \frac{2K}{E}.
+$$
+
+For the 20 Mb 1000 Genomes file, $K/E = 0.01819$, so the compressed weights occupy 3.64% of the original weight-array memory.
+
+### In-memory effect
+
+| Block layout | Original weights | Compressed weights | Weight reduction | Core graph reduction |
+|---|---:|---:|---:|---:|
+| 20 Mb blocks | 814.1 MB | 29.6 MB | 96.4% | 36.6% |
+| 1 Mb blocks | 821.3 MB | 28.6 MB | 96.5% | 36.1% |
+
+“Core graph” includes the CSC topology, edge weights, variant indices, flip flags, and non-unique workspace mapping. It excludes variant strings and other optional metadata that are not required for algebra-only loading.
+
+The implementation is opt-in:
+
+```python
+linarg = LinearARG.read(path, block=block, compress_edge_weights=True)
+```
+
+The default loading path still constructs the existing SciPy CSC matrix.
+
+### On-disk effect
+
+The existing HDF5 schema stores `indptr`, `indices`, and `data`. The optional compressed schema stores:
+
+```text
+indptr
+indices
+nonunit_edge_indices
+nonunit_values
+```
+
+and sets the group attribute:
+
+```text
+edge_weight_encoding = "one_sparse_v1"
+```
+
+The `data` dataset is omitted. Readers can either retain the compressed representation or reconstruct an ordinary CSC `data` array. Existing HDF5 files remain readable, and uncompressed writing remains the default.
+
+The on-disk reduction is much smaller than the in-memory reduction because HDF5 gzip compression already encodes a long, repetitive integer array efficiently. On three representative 20 Mb blocks, the optional format reduced total serialized size by 1.6%, 2.4%, and 1.9%. The main benefit is therefore resident memory, particularly when several blocks are loaded by parallel workers, rather than disk capacity.
+
+## Propagation to the triangular solvers
+
+A LinearARG represents a genotype matrix through triangular solves involving $I-A$. Both forward and reverse products traverse the graph in topological order. Removing `data` means that the solvers must obtain weights from the implicit-one representation without adding an expensive lookup to every edge.
+
+### Matrix-vector multiplication
+
+The original forward operation is conceptually:
+
+```text
+for source node u in topological order:
+    for edge e = (u -> v):
+        x[v] += data[e] * x[u]
+```
+
+The compressed solver first treats every edge in a source column as a unit edge, then corrects the few non-unit edges before moving to the next source node:
+
+```text
+for source node u in topological order:
+    for edge e = (u -> v):
+        x[v] += x[u]
+
+    for non-unit edge e = (u -> v) with stored weight w:
+        x[v] += (w - 1) * x[u]
+```
+
+The correction must occur before advancing to the next source node because destination values can contribute to later nodes. Within one source column, however, all edges use the same source value, so the unit contribution and correction are algebraically equivalent to applying the stored weight directly.
+
+The reverse solver uses the same idea while traversing nodes and edge positions in reverse order. It first accumulates all child values with unit weight and then applies the sparse corrections for that column.
+
+This design has two useful properties:
+
+1. The main edge traversal no longer reads the dense weight array or performs a multiplication for unit edges.
+2. Exception checks occur once per source column, not once per edge.
+
+Forward and reverse matrix-vector results agreed with the original implementation to normal floating-point precision; the largest observed absolute difference was below $5\times10^{-12}$.
+
+### Matrix-matrix multiplication
+
+Matrix-matrix operations propagate a short vector of trait values per graph node. The existing implementation calls BLAS `axpy` once per edge:
+
+$$
+\mathbf{x}_v \leftarrow \mathbf{x}_v + w_e\mathbf{x}_u.
+$$
+
+An initial compressed implementation processed every edge with $w_e=1$ and then issued a second BLAS call for each correction. This was fast for matrix-vector multiplication but added approximately 1–2% overhead to some matrix-matrix operations.
+
+The final kernel instead divides each CSC column into contiguous runs separated by non-unit edge positions:
+
+1. Process a run of unit edges with BLAS scalar $\alpha=1$.
+2. Process the next non-unit edge once with its stored scalar.
+3. Continue with the next unit run.
+
+This preserves the original edge order, performs exactly one BLAS call per edge, and avoids a conditional branch for every unit edge. The forward and reverse float32 and float64 kernels retain the existing non-unique workspace mapping and the rules for zeroing reusable workspace columns.
+
+## Alternatives evaluated
+
+### Separate $-1$ and general-exception streams
+
+Because most non-unit weights are $-1$, a more compact representation can store only an index for each $-1$ edge and index/value pairs for all remaining exceptions. For the 20 Mb file, this would reduce edge-weight memory from 29.6 MB to approximately 15.5 MB.
+
+This form was rejected because the solver had to track two exception streams. Even after matching the original edge traversal order, reverse matrix-vector multiplication remained measurably slower. The single-stream representation sacrifices less than one percentage point of total core-graph memory reduction and has better runtime behavior.
+
+### Dense 8-bit weights
+
+All observed weights fit in an 8-bit signed integer, so another option would be to change `data` from `int32` to `int8`. This would reduce the 20 Mb weight arrays from 814.1 MB to 203.5 MB. It is simple and likely cache-friendly, but it saves substantially less memory than the chosen sparse representation. It was not pursued after the sparse kernels met the runtime objective.
+
+## Runtime results
+
+Benchmarks were run on an Apple M4 Max. Default and compressed calls were alternated, and reported values are ratios of median compressed runtime to median original runtime. Ratios below one indicate a speedup.
+
+### Full 1000 Genomes, 20 Mb blocks
+
+Three blocks spanning the observed range of graph sizes were tested.
+
+| Operation | Runtime-ratio range | Interpretation |
+|---|---:|---|
+| Forward matvec | 0.917–0.976 | 2.4–8.3% faster |
+| Reverse matvec | 0.947–0.995 | 0.5–5.3% faster |
+| Forward matmat, 8 columns | 0.956–0.977 | 2.3–4.4% faster |
+| Reverse matmat, 8 columns | 0.997–1.011 | tied to 1.1% slower |
+| Forward matmat, 32 columns | 0.949–0.974 | 2.6–5.1% faster |
+| Reverse matmat, 32 columns | 0.953–0.965 | 3.5–4.7% faster |
+
+### Full 1000 Genomes, 1 Mb blocks
+
+Five blocks spanning the observed range of graph sizes were tested.
+
+| Operation | Median runtime ratio | Observed range |
+|---|---:|---:|
+| Forward matvec | 0.983 | 0.898–0.994 |
+| Reverse matvec | 1.004 | 0.949–1.007 |
+| Forward matmat, 8 columns | 0.990 | 0.982–1.015 |
+| Reverse matmat, 8 columns | 1.010 | 0.989–1.014 |
+| Forward matmat, 32 columns | 0.960 | 0.937–0.986 |
+| Reverse matmat, 32 columns | 0.968 | 0.900–0.997 |
+
+The smaller 1 Mb blocks make sub-percent fixed overheads easier to see. Forward matvec remained faster in every tested block. Reverse matvec and narrow reverse matmat were effectively tied, while wider matrix-matrix operations were consistently faster.
+
+## Counterexample: a sample-thinned LinearARG
+
+The 50-haplotype chromosome file had a different distribution:
+
+- 88.12% of edges had weight $+1$;
+- 10.33% had weight $-1$; and
+- 1.56% had another value.
+
+Compressed weights occupied 23.8% of the original weight memory, but topology and workspace arrays dominated the graph. Total core memory fell by only 6.6%, while matrix-vector multiplication slowed by approximately 8–10%.
+
+This graph does not contain individual nodes, so the result demonstrates that the relevant selection criterion is the actual non-unit edge fraction and graph structure, not only the presence or absence of individual nodes. A production default should inspect the projected memory ratio, and potentially an edge-to-node measure, before selecting the compressed representation.
+
+## Conclusions
+
+Implicitly storing the common edge weight is effective for full-cohort 1000 Genomes LinearARGs. The selected representation reduces core graph memory by roughly 36–37% while preserving or improving the cost of the primary forward matrix-vector operation. The solver changes are important: a naive sparse lookup or second BLAS pass can give back the computational benefit, whereas column-local corrections for matvec and run-segmented traversal for matmat exploit the CSC ordering efficiently.
+
+The representation should remain optional or be selected adaptively. It is highly favorable when approximately 98% of edges have weight one, but it is not favorable for every LinearARG construction.
+
+## Reproducing the analysis
+
+The benchmark driver is `benchmarks/benchmark_one_sparse.py`. It reports edge-weight distributions, projected and realized array memory, numerical differences, and alternating median runtimes for forward and reverse matvec and matmat operations. The raw benchmark outputs are stored under `benchmarks/results/`.

--- a/src/linear_dag/__init__.py
+++ b/src/linear_dag/__init__.py
@@ -12,6 +12,7 @@ from .core import (
     linear_arg_from_genotypes as linear_arg_from_genotypes,
     LinearARG as LinearARG,
     list_blocks as list_blocks,
+    OneSparseMatrix as OneSparseMatrix,
     ParallelOperator as ParallelOperator,
 )
 from .genotype import (

--- a/src/linear_dag/association/blup.py
+++ b/src/linear_dag/association/blup.py
@@ -23,6 +23,11 @@ class triangular_solver(LinearOperator):
 
     A: csr_matrix
 
+    def __post_init__(self) -> None:
+        scipy_array_operator = aslinearoperator(np.empty((0, 0)))
+        if hasattr(scipy_array_operator, "_xp"):
+            self._xp = scipy_array_operator._xp
+
     @property
     def dtype(self):
         """Return the scalar dtype used by the wrapped sparse matrix."""
@@ -68,7 +73,8 @@ def blup(linarg: LinearARG, heritability: float, y: np.ndarray):
 
     X = linarg
     n, m = X.shape
-    k = linarg.A.shape[0]
+    adjacency = linarg.A.tocsc(copy=False)
+    k = adjacency.shape[0]
 
     ## Generate M and S
     M = csc_matrix(eye(k))
@@ -95,7 +101,7 @@ def blup(linarg: LinearARG, heritability: float, y: np.ndarray):
 
     ## Generate B
     I = eye(k)  # noqa: E741
-    I_minus_A = aslinearoperator(I - X.A)
+    I_minus_A = aslinearoperator(I - adjacency)
     B = (I_minus_A.T @ Om) @ I_minus_A
 
     # B_s,s * y
@@ -105,7 +111,7 @@ def blup(linarg: LinearARG, heritability: float, y: np.ndarray):
     second_term = T @ (B @ (S.T @ y))
 
     SigmaTilde = aslinearoperator(diags(SigmaTilde[non_sample_indices]))
-    adjacency_matrix = linarg.A[non_sample_indices, :]
+    adjacency_matrix = adjacency[non_sample_indices, :]
     adjacency_matrix = adjacency_matrix[:, non_sample_indices]
     linarg_adjacency_submatrix_nonsamples = triangular_solver(adjacency_matrix)
     preconditioner = linarg_adjacency_submatrix_nonsamples @ SigmaTilde @ linarg_adjacency_submatrix_nonsamples.T

--- a/src/linear_dag/core/__init__.py
+++ b/src/linear_dag/core/__init__.py
@@ -1,6 +1,7 @@
 from .brick_graph import BrickGraph as BrickGraph
 from .linear_arg_inference import linear_arg_from_genotypes as linear_arg_from_genotypes
 from .lineararg import LinearARG as LinearARG, list_blocks as list_blocks
+from .one_sparse import OneSparseMatrix as OneSparseMatrix
 from .parallel_processing import (
     GRMOperator as GRMOperator,
     ParallelOperator as ParallelOperator,

--- a/src/linear_dag/core/lineararg.py
+++ b/src/linear_dag/core/lineararg.py
@@ -758,7 +758,7 @@ class LinearARG(LinearOperator):
         block_info: Optional[dict] = None,
         compression_option: str = "gzip",
         save_allele_counts: bool = True,
-        compress_edge_weights: bool = True,
+        compress_edge_weights: bool = False,
     ):
         """Write this LinearARG to HDF5 in the package's on-disk schema.
 
@@ -886,7 +886,7 @@ class LinearARG(LinearOperator):
         save_threshold: bool = False,
         codec: str = "zstd",
         level: int = 5,
-        compress_edge_weights: bool = True,
+        compress_edge_weights: bool = False,
     ):
         """Write this LinearARG to HDF5 using Blosc-compressed datasets.
 

--- a/src/linear_dag/core/lineararg.py
+++ b/src/linear_dag/core/lineararg.py
@@ -23,13 +23,18 @@ from linear_dag.genotype import read_vcf
 
 from .digraph import DiGraph
 from .linear_arg_inference import linear_arg_from_genotypes
+from .one_sparse import OneSparseMatrix
 from .one_summed_cy import linearize_brick_graph
 from .solve import (
     add_at,
     spsolve_backward_triangular,
     spsolve_backward_triangular_matmat,
+    spsolve_backward_triangular_matmat_one_sparse,
+    spsolve_backward_triangular_one_sparse,
     spsolve_forward_triangular,
     spsolve_forward_triangular_matmat,
+    spsolve_forward_triangular_matmat_one_sparse,
+    spsolve_forward_triangular_one_sparse,
     topological_sort,
 )
 
@@ -63,7 +68,7 @@ class LinearARG(LinearOperator):
         ```
     """
 
-    A: csc_matrix  # samples must be in descending order starting from the final row/col
+    A: Union[csc_matrix, OneSparseMatrix]  # samples must descend from the final row/col
     variant_indices: npt.NDArray[np.int32]
     flip: npt.NDArray[np.bool_]
     n_samples: np.int32
@@ -448,7 +453,10 @@ class LinearARG(LinearOperator):
         vi = np.zeros(self.A.shape[0], dtype=np.float64)
         vi[self.individual_indices[indiv_to_include]] = 2
         vi[self.sample_indices[np.repeat(indiv_to_include, 2)]] = -1
-        spsolve_backward_triangular(self.A, vi)
+        if isinstance(self.A, OneSparseMatrix):
+            spsolve_backward_triangular_one_sparse(self.A, vi)
+        else:
+            spsolve_backward_triangular(self.A, vi)
         return vi[self.variant_indices].astype(np.int32)
 
     def number_of_carriers(self, indiv_to_include: np.ndarray | None = None):
@@ -481,7 +489,10 @@ class LinearARG(LinearOperator):
         # n1 + n2
         vi = np.zeros(self.A.shape[0], dtype=np.float64)
         vi[self.individual_indices[indiv_to_include]] = 1
-        spsolve_backward_triangular(self.A, vi)
+        if isinstance(self.A, OneSparseMatrix):
+            spsolve_backward_triangular_one_sparse(self.A, vi)
+        else:
+            spsolve_backward_triangular(self.A, vi)
         alt_carriers = vi[self.variant_indices]
 
         if not np.any(self.flip):
@@ -490,7 +501,10 @@ class LinearARG(LinearOperator):
         # n1 + 2*n2
         vh = np.zeros(self.A.shape[0], dtype=np.float64)
         vh[self.sample_indices[np.repeat(indiv_to_include, 2)]] = 1
-        spsolve_backward_triangular(self.A, vh)
+        if isinstance(self.A, OneSparseMatrix):
+            spsolve_backward_triangular_one_sparse(self.A, vh)
+        else:
+            spsolve_backward_triangular(self.A, vh)
         hap_counts = vh[self.variant_indices]
 
         # handle flipped variants
@@ -616,7 +630,12 @@ class LinearARG(LinearOperator):
 
         variant_nonunique_indices = self.nonunique_indices[self.variant_indices]
         add_at(v, variant_nonunique_indices, temp)
-        spsolve_forward_triangular_matmat(self.A, v, self.nonunique_indices, int(self.sample_indices[-1]))
+        if isinstance(self.A, OneSparseMatrix):
+            spsolve_forward_triangular_matmat_one_sparse(
+                self.A, v, self.nonunique_indices, int(self.sample_indices[-1])
+            )
+        else:
+            spsolve_forward_triangular_matmat(self.A, v, self.nonunique_indices, int(self.sample_indices[-1]))
         sample_nonunique_indices = self.nonunique_indices[self.sample_indices]
         return v[:, sample_nonunique_indices].T + np.sum(other[self.flip], axis=0)
 
@@ -632,7 +651,12 @@ class LinearARG(LinearOperator):
         v = np.zeros((other.shape[1], self.num_nonunique_indices), dtype=other.dtype, order="F")
         sample_nonunique_indices = self.nonunique_indices[self.sample_indices]
         v[:, sample_nonunique_indices] = other.T
-        spsolve_backward_triangular_matmat(self.A, v, self.nonunique_indices, int(self.sample_indices[-1]))
+        if isinstance(self.A, OneSparseMatrix):
+            spsolve_backward_triangular_matmat_one_sparse(
+                self.A, v, self.nonunique_indices, int(self.sample_indices[-1])
+            )
+        else:
+            spsolve_backward_triangular_matmat(self.A, v, self.nonunique_indices, int(self.sample_indices[-1]))
         variant_nonunique_indices = self.nonunique_indices[self.variant_indices]
         v = v[:, variant_nonunique_indices]
         if np.any(self.flip):
@@ -669,7 +693,10 @@ class LinearARG(LinearOperator):
         v = np.zeros(self.A.shape[0], dtype=np.float64)
         temp = other.ravel().astype(np.float64) * ((-1) ** self.flip.ravel())
         np.add.at(v, self.variant_indices, temp)  # handles duplicate variant indices
-        spsolve_forward_triangular(self.A, v)
+        if isinstance(self.A, OneSparseMatrix):
+            spsolve_forward_triangular_one_sparse(self.A, v)
+        else:
+            spsolve_forward_triangular(self.A, v)
         result = np.asarray(v[self.sample_indices]) + np.sum(other[self.flip])
         return result if other.ndim == 1 else result.reshape(-1, 1)
 
@@ -683,7 +710,10 @@ class LinearARG(LinearOperator):
             )
         v = np.zeros(self.A.shape[0], dtype=np.float64)
         v[self.sample_indices] = other.ravel().astype(np.float64)
-        spsolve_backward_triangular(self.A, v)
+        if isinstance(self.A, OneSparseMatrix):
+            spsolve_backward_triangular_one_sparse(self.A, v)
+        else:
+            spsolve_backward_triangular(self.A, v)
         v = v[self.variant_indices]
         if np.any(self.flip):
             v[self.flip] = np.sum(other) - v[self.flip]
@@ -718,6 +748,7 @@ class LinearARG(LinearOperator):
         block_info: Optional[dict] = None,
         compression_option: str = "gzip",
         save_allele_counts: bool = True,
+        compress_edge_weights: bool = False,
     ):
         """Write this LinearARG to HDF5 in the package's on-disk schema.
 
@@ -732,6 +763,7 @@ class LinearARG(LinearOperator):
         - `h5_fname`: Base path/prefix used for output files.
         - `block_info`: Optional dictionary with keys `chrom`, `start`, and `end`.
         - `compression_option`: HDF5 compression option.
+        - `compress_edge_weights`: Store only indices and values of non-unit edges.
         - `save_allele_counts`: Whether to persist per-variant
           $\\mathbf{1}^\\top X$ counts for faster reloads.
 
@@ -768,7 +800,24 @@ class LinearARG(LinearOperator):
 
             destination.create_dataset("indptr", data=self.A.indptr, compression=compression_option, shuffle=True)
             destination.create_dataset("indices", data=self.A.indices, compression=compression_option, shuffle=True)
-            destination.create_dataset("data", data=self.A.data, compression=compression_option, shuffle=True)
+            if compress_edge_weights:
+                compressed_A = self.A if isinstance(self.A, OneSparseMatrix) else OneSparseMatrix.from_csc(self.A)
+                destination.attrs["edge_weight_encoding"] = "one_sparse_v1"
+                destination.create_dataset(
+                    "nonunit_edge_indices",
+                    data=compressed_A.nonunit_edge_indices,
+                    compression=compression_option,
+                    shuffle=True,
+                )
+                destination.create_dataset(
+                    "nonunit_values",
+                    data=compressed_A.nonunit_values,
+                    compression=compression_option,
+                    shuffle=True,
+                )
+            else:
+                data = self.A.to_csc().data if isinstance(self.A, OneSparseMatrix) else self.A.data
+                destination.create_dataset("data", data=data, compression=compression_option, shuffle=True)
             destination.create_dataset(
                 "variant_indices", data=self.variant_indices, compression=compression_option, shuffle=True
             )
@@ -894,7 +943,8 @@ class LinearARG(LinearOperator):
             # Write main datasets with Blosc compression
             destination.create_dataset("indptr", data=self.A.indptr, compression=get_blosc_filter(self.A.indptr))
             destination.create_dataset("indices", data=self.A.indices, compression=get_blosc_filter(self.A.indices))
-            destination.create_dataset("data", data=self.A.data, compression=get_blosc_filter(self.A.data))
+            data = self.A.to_csc().data if isinstance(self.A, OneSparseMatrix) else self.A.data
+            destination.create_dataset("data", data=data, compression=get_blosc_filter(data))
             destination.create_dataset(
                 "variant_indices", data=self.variant_indices, compression=get_blosc_filter(self.variant_indices)
             )
@@ -983,6 +1033,7 @@ class LinearARG(LinearOperator):
         h5_fname: Union[str, PathLike],
         block: Optional[str] = None,
         load_metadata: bool = False,
+        compress_edge_weights: bool = False,
     ) -> "LinearARG":
         """Read a [`linear_dag.core.lineararg.LinearARG`][] from HDF5 storage.
 
@@ -998,6 +1049,7 @@ class LinearARG(LinearOperator):
 
         - `h5_fname`: Base path/prefix of the HDF5 file.
         - `block`: Optional block/group name.
+        - `compress_edge_weights`: Keep only non-unit edge weights in memory.
         - `load_metadata`: Whether to load variant metadata into `variants`.
 
         **Returns:**
@@ -1025,7 +1077,23 @@ class LinearARG(LinearOperator):
         with h5py.File(fname, "r") as file:
             iids = pl.Series(file["iids"][:].astype(str))
             f = file[block] if block else file
-            A = csc_matrix((f["data"][:], f["indices"][:], f["indptr"][:]), shape=(f.attrs["n"], f.attrs["n"]))
+            shape = (f.attrs["n"], f.attrs["n"])
+            if "data" in f:
+                A = csc_matrix((f["data"][:], f["indices"][:], f["indptr"][:]), shape=shape)
+                if compress_edge_weights:
+                    A = OneSparseMatrix.from_csc(A)
+            elif f.attrs.get("edge_weight_encoding") == "one_sparse_v1":
+                A = OneSparseMatrix(
+                    indptr=f["indptr"][:],
+                    indices=f["indices"][:],
+                    nonunit_edge_indices=f["nonunit_edge_indices"][:],
+                    nonunit_values=f["nonunit_values"][:],
+                    shape=shape,
+                )
+                if not compress_edge_weights:
+                    A = A.to_csc()
+            else:
+                raise ValueError("LinearARG block has no recognized edge-weight encoding")
             variant_indices = f["variant_indices"][:]
             flip = f["flip"][:]
             n_samples = f.attrs["n_samples"]

--- a/src/linear_dag/core/lineararg.py
+++ b/src/linear_dag/core/lineararg.py
@@ -59,6 +59,11 @@ class LinearARG(LinearOperator):
         Sample nodes are stored at the tail of the graph. `shape` is derived
         from `sample_indices` and `variant_indices`, not directly from `A.shape`.
 
+        `A` is stored as a
+        [`linear_dag.core.one_sparse.OneSparseMatrix`][], with unit edge weights
+        represented implicitly. Use `A.to_csc()` only at boundaries that
+        require a SciPy sparse matrix.
+
     !!! Example
 
         ```python
@@ -80,6 +85,11 @@ class LinearARG(LinearOperator):
     # allele_counts: Optional[npt.NDArray[np.int32]] = None
 
     def __post_init__(self) -> None:
+        if isinstance(self.A, csc_matrix):
+            self.A = OneSparseMatrix.from_csc(self.A)
+        elif not isinstance(self.A, OneSparseMatrix):
+            raise TypeError("LinearARG adjacency must be a CSC or OneSparseMatrix")
+
         # SciPy's LinearOperator namespace checks expect subclasses to define
         # this attribute. LinearARG exposes shape/dtype as derived properties,
         # so it cannot call LinearOperator.__init__ directly.
@@ -538,7 +548,7 @@ class LinearARG(LinearOperator):
         """
         variant_node_indices = self.variant_indices[variant_indices]
         if self.n_individuals is None:
-            A = self.A
+            A = self.A.tocsc(copy=False)
         else:
             n = self.A.shape[0] - self.n_individuals
             A = self.A[:n, :][:, :n]
@@ -578,14 +588,14 @@ class LinearARG(LinearOperator):
         else:
             nodes_to_remove = self.sample_indices[sample_indices_to_remove]
 
-        A = self.A
+        A = self.A.tocsc(copy=False)
         nodes_to_keep = np.setdiff1d(np.arange(A.shape[0]), nodes_to_remove)
         A = A.tocsr()
         A = A[nodes_to_keep, :].tocsc()  # efficient row slice, then convert back to CSC
         A = A[:, nodes_to_keep]
 
         linarg_samples_removed = LinearARG(A, self.variant_indices, self.flip, len(iids_to_keep))
-        linarg_samples_removed.iids = pl.Series(iids_to_keep).cast(pl.Int64)
+        linarg_samples_removed.iids = pl.Series(iids_to_keep).cast(self.iids.dtype)
 
         if self.n_individuals is not None:
             linarg_samples_removed.n_individuals = self.n_individuals - len(iids_to_remove)
@@ -609,7 +619,7 @@ class LinearARG(LinearOperator):
         v = np.zeros((self.A.shape[0], other.shape[1]), dtype=other.dtype)
         temp = (other.T * (-1) ** self.flip).T
         np.add.at(v, self.variant_indices, temp)
-        x = spsolve_triangular(eye(self.A.shape[0]) - self.A, v)
+        x = spsolve_triangular(eye(self.A.shape[0]) - self.A.tocsc(copy=False), v)
         return x[self.sample_indices] + np.sum(other[self.flip], axis=0)
 
     def _matmat(self, other: npt.ArrayLike) -> npt.NDArray[np.number]:
@@ -673,7 +683,7 @@ class LinearARG(LinearOperator):
         v = np.zeros((other.shape[0], self.A.shape[1]), dtype=other.dtype)
         v[:, self.sample_indices] = other
 
-        x = spsolve_triangular(eye(self.A.shape[1]) - self.A.T, v.T, lower=False)
+        x = spsolve_triangular(eye(self.A.shape[1]) - self.A.tocsc(copy=False).T, v.T, lower=False)
 
         x = x[self.variant_indices]
         if np.any(self.flip):
@@ -748,7 +758,7 @@ class LinearARG(LinearOperator):
         block_info: Optional[dict] = None,
         compression_option: str = "gzip",
         save_allele_counts: bool = True,
-        compress_edge_weights: bool = False,
+        compress_edge_weights: bool = True,
     ):
         """Write this LinearARG to HDF5 in the package's on-disk schema.
 
@@ -763,7 +773,8 @@ class LinearARG(LinearOperator):
         - `h5_fname`: Base path/prefix used for output files.
         - `block_info`: Optional dictionary with keys `chrom`, `start`, and `end`.
         - `compression_option`: HDF5 compression option.
-        - `compress_edge_weights`: Store only indices and values of non-unit edges.
+        - `compress_edge_weights`: Store only indices and values of non-unit
+          edges. Set to `False` to write the legacy `data` dataset.
         - `save_allele_counts`: Whether to persist per-variant
           $\\mathbf{1}^\\top X$ counts for faster reloads.
 
@@ -875,6 +886,7 @@ class LinearARG(LinearOperator):
         save_threshold: bool = False,
         codec: str = "zstd",
         level: int = 5,
+        compress_edge_weights: bool = True,
     ):
         """Write this LinearARG to HDF5 using Blosc-compressed datasets.
 
@@ -892,6 +904,8 @@ class LinearARG(LinearOperator):
         - `save_threshold`: Whether to save threshold summary attributes.
         - `codec`: Blosc codec (`'zstd'`, `'lz4'`, `'lz4hc'`, `'zlib'`).
         - `level`: Blosc compression level (`0-9`).
+        - `compress_edge_weights`: Store only indices and values of non-unit
+          edges. Set to `False` to write the legacy `data` dataset.
 
         **Returns:**
 
@@ -943,8 +957,22 @@ class LinearARG(LinearOperator):
             # Write main datasets with Blosc compression
             destination.create_dataset("indptr", data=self.A.indptr, compression=get_blosc_filter(self.A.indptr))
             destination.create_dataset("indices", data=self.A.indices, compression=get_blosc_filter(self.A.indices))
-            data = self.A.to_csc().data if isinstance(self.A, OneSparseMatrix) else self.A.data
-            destination.create_dataset("data", data=data, compression=get_blosc_filter(data))
+            if compress_edge_weights:
+                compressed_A = self.A if isinstance(self.A, OneSparseMatrix) else OneSparseMatrix.from_csc(self.A)
+                destination.attrs["edge_weight_encoding"] = "one_sparse_v1"
+                destination.create_dataset(
+                    "nonunit_edge_indices",
+                    data=compressed_A.nonunit_edge_indices,
+                    compression=get_blosc_filter(compressed_A.nonunit_edge_indices),
+                )
+                destination.create_dataset(
+                    "nonunit_values",
+                    data=compressed_A.nonunit_values,
+                    compression=get_blosc_filter(compressed_A.nonunit_values),
+                )
+            else:
+                data = self.A.to_csc().data if isinstance(self.A, OneSparseMatrix) else self.A.data
+                destination.create_dataset("data", data=data, compression=get_blosc_filter(data))
             destination.create_dataset(
                 "variant_indices", data=self.variant_indices, compression=get_blosc_filter(self.variant_indices)
             )
@@ -1033,7 +1061,7 @@ class LinearARG(LinearOperator):
         h5_fname: Union[str, PathLike],
         block: Optional[str] = None,
         load_metadata: bool = False,
-        compress_edge_weights: bool = False,
+        compress_edge_weights: bool = True,
     ) -> "LinearARG":
         """Read a [`linear_dag.core.lineararg.LinearARG`][] from HDF5 storage.
 
@@ -1049,7 +1077,9 @@ class LinearARG(LinearOperator):
 
         - `h5_fname`: Base path/prefix of the HDF5 file.
         - `block`: Optional block/group name.
-        - `compress_edge_weights`: Keep only non-unit edge weights in memory.
+        - `compress_edge_weights`: Deprecated compatibility argument. LinearARG
+          adjacency is always compressed in memory; use `linarg.A.to_csc()` at
+          a boundary that requires a SciPy sparse matrix.
         - `load_metadata`: Whether to load variant metadata into `variants`.
 
         **Returns:**
@@ -1078,20 +1108,28 @@ class LinearARG(LinearOperator):
             iids = pl.Series(file["iids"][:].astype(str))
             f = file[block] if block else file
             shape = (f.attrs["n"], f.attrs["n"])
+            if not compress_edge_weights:
+                import warnings
+
+                warnings.warn(
+                    "LinearARG adjacency is always compressed in memory; "
+                    "use `linarg.A.to_csc()` for a SciPy CSC adapter",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
             if "data" in f:
-                A = csc_matrix((f["data"][:], f["indices"][:], f["indptr"][:]), shape=shape)
-                if compress_edge_weights:
-                    A = OneSparseMatrix.from_csc(A)
+                A = OneSparseMatrix.from_csc(
+                    csc_matrix((f["data"][:], f["indices"][:], f["indptr"][:]), shape=shape)
+                )
             elif f.attrs.get("edge_weight_encoding") == "one_sparse_v1":
                 A = OneSparseMatrix(
-                    indptr=f["indptr"][:],
-                    indices=f["indices"][:],
-                    nonunit_edge_indices=f["nonunit_edge_indices"][:],
-                    nonunit_values=f["nonunit_values"][:],
+                    indptr=np.asarray(f["indptr"][:], dtype=np.int32),
+                    indices=np.asarray(f["indices"][:], dtype=np.int32),
+                    nonunit_edge_indices=np.asarray(f["nonunit_edge_indices"][:], dtype=np.int32),
+                    nonunit_values=np.asarray(f["nonunit_values"][:], dtype=np.int32),
                     shape=shape,
                 )
-                if not compress_edge_weights:
-                    A = A.to_csc()
             else:
                 raise ValueError("LinearARG block has no recognized edge-weight encoding")
             variant_indices = f["variant_indices"][:]
@@ -1260,7 +1298,7 @@ class LinearARG(LinearOperator):
 
         - New [`linear_dag.core.lineararg.LinearARG`][] instance that includes individual nodes.
         """
-        A, individual_indices = add_individuals_to_graph(self.A, self.sample_indices, sex=sex)
+        A, individual_indices = add_individuals_to_graph(self.A.tocsc(copy=False), self.sample_indices, sex=sex)
         individuals_graph = DiGraph.from_csr(A)  # edges are defined the other way around
         A = csc_matrix(linearize_brick_graph(individuals_graph))
         linarg = LinearARG(

--- a/src/linear_dag/core/one_sparse.py
+++ b/src/linear_dag/core/one_sparse.py
@@ -1,0 +1,157 @@
+from dataclasses import dataclass
+
+import numpy as np
+
+from scipy.sparse import csc_matrix
+
+
+@dataclass(frozen=True)
+class OneSparseMatrix:
+    """CSC topology whose edge weights are implicitly one except for sparse exceptions.
+
+    Non-unit edges retain an index and a value. Edge indices refer to positions
+    in the CSC `indices` array and must be sorted.
+
+    !!! Example
+
+        ```python
+        compressed = OneSparseMatrix.from_csc(adjacency)
+        assert np.array_equal(compressed.to_csc().toarray(), adjacency.toarray())
+        ```
+    """
+
+    indptr: np.ndarray
+    indices: np.ndarray
+    nonunit_edge_indices: np.ndarray
+    nonunit_values: np.ndarray
+    shape: tuple[int, int]
+
+    def __post_init__(self) -> None:
+        arrays = (
+            self.indptr,
+            self.indices,
+            self.nonunit_edge_indices,
+            self.nonunit_values,
+        )
+        if any(array.dtype != np.int32 for array in arrays):
+            raise TypeError("OneSparseMatrix arrays must all have dtype int32")
+        if self.indptr.ndim != 1 or self.indices.ndim != 1:
+            raise ValueError("CSC indptr and indices must be one-dimensional")
+        if self.indptr.size != self.shape[1] + 1:
+            raise ValueError("indptr length must equal the number of columns plus one")
+        if self.indptr[-1] != self.indices.size:
+            raise ValueError("the final indptr entry must equal the number of edges")
+        if self.nonunit_edge_indices.size != self.nonunit_values.size:
+            raise ValueError("non-unit edge indices and values must have equal length")
+        if self.nonunit_edge_indices.size:
+            if self.nonunit_edge_indices[0] < 0 or self.nonunit_edge_indices[-1] >= self.indices.size:
+                raise ValueError("non-unit edge indices must index the CSC edge array")
+            if np.any(self.nonunit_edge_indices[1:] <= self.nonunit_edge_indices[:-1]):
+                raise ValueError("non-unit edge indices must be strictly increasing")
+
+    @classmethod
+    def from_csc(cls, matrix: csc_matrix) -> "OneSparseMatrix":
+        """Compress a CSC matrix whose most common edge weight is one.
+
+        **Arguments:**
+
+        - `matrix`: Sparse matrix with integer-valued edge weights.
+
+        **Returns:**
+
+        - A matrix retaining CSC topology and only non-unit edge weights.
+        """
+        matrix = matrix.tocsc(copy=False)
+        data = np.asarray(matrix.data)
+        nonunit = np.flatnonzero(data != 1).astype(np.int32)
+        return cls(
+            indptr=np.asarray(matrix.indptr, dtype=np.int32).copy(),
+            indices=np.asarray(matrix.indices, dtype=np.int32).copy(),
+            nonunit_edge_indices=nonunit,
+            nonunit_values=np.asarray(data[nonunit], dtype=np.int32),
+            shape=matrix.shape,
+        )
+
+    @property
+    def nnz(self) -> int:
+        """Return the number of stored edges.
+
+        **Returns:**
+
+        - Number of entries in the CSC topology.
+        """
+        return self.indices.size
+
+    @property
+    def dtype(self) -> np.dtype:
+        """Return the logical edge-weight dtype.
+
+        **Returns:**
+
+        - NumPy `int32` dtype.
+        """
+        return np.dtype(np.int32)
+
+    @property
+    def nbytes(self) -> int:
+        """Return bytes used by topology and compressed edge weights.
+
+        **Returns:**
+
+        - Sum of the four backing arrays' allocated bytes.
+        """
+        return sum(
+            array.nbytes
+            for array in (
+                self.indptr,
+                self.indices,
+                self.nonunit_edge_indices,
+                self.nonunit_values,
+            )
+        )
+
+    @property
+    def edge_weight_nbytes(self) -> int:
+        """Return bytes used only by non-unit edge metadata.
+
+        **Returns:**
+
+        - Bytes occupied by non-unit edge indices and values.
+        """
+        return self.nonunit_edge_indices.nbytes + self.nonunit_values.nbytes
+
+    def to_csc(self) -> csc_matrix:
+        """Materialize the logical matrix as an ordinary SciPy CSC matrix.
+
+        **Returns:**
+
+        - Equivalent CSC matrix with a dense `int32` values array.
+        """
+        data = np.ones(self.nnz, dtype=np.int32)
+        data[self.nonunit_edge_indices] = self.nonunit_values
+        return csc_matrix((data, self.indices.copy(), self.indptr.copy()), shape=self.shape)
+
+    def copy(self) -> "OneSparseMatrix":
+        """Return a deep copy of this matrix.
+
+        **Returns:**
+
+        - Independent [`linear_dag.core.one_sparse.OneSparseMatrix`][].
+        """
+        return OneSparseMatrix(
+            self.indptr.copy(),
+            self.indices.copy(),
+            self.nonunit_edge_indices.copy(),
+            self.nonunit_values.copy(),
+            self.shape,
+        )
+
+    def __getitem__(self, key):
+        return self.to_csc()[key]
+
+    @property
+    def T(self):
+        return self.to_csc().T
+
+    def __rsub__(self, other):
+        return other - self.to_csc()

--- a/src/linear_dag/core/one_sparse.py
+++ b/src/linear_dag/core/one_sparse.py
@@ -26,6 +26,8 @@ class OneSparseMatrix:
     nonunit_values: np.ndarray
     shape: tuple[int, int]
 
+    __array_priority__ = 10.1
+
     def __post_init__(self) -> None:
         arrays = (
             self.indptr,
@@ -93,6 +95,24 @@ class OneSparseMatrix:
         return np.dtype(np.int32)
 
     @property
+    def data(self) -> np.ndarray:
+        """Materialize the logical CSC edge-weight array.
+
+        !!! info
+
+            The returned array is independent. Mutating it does not change the
+            compressed matrix; use [`linear_dag.core.one_sparse.OneSparseMatrix.to_csc`][]
+            when a mutable SciPy sparse matrix is required.
+
+        **Returns:**
+
+        - Dense `int32` edge weights aligned to `indices`.
+        """
+        data = np.ones(self.nnz, dtype=np.int32)
+        data[self.nonunit_edge_indices] = self.nonunit_values
+        return data
+
+    @property
     def nbytes(self) -> int:
         """Return bytes used by topology and compressed edge weights.
 
@@ -127,9 +147,7 @@ class OneSparseMatrix:
 
         - Equivalent CSC matrix with a dense `int32` values array.
         """
-        data = np.ones(self.nnz, dtype=np.int32)
-        data[self.nonunit_edge_indices] = self.nonunit_values
-        return csc_matrix((data, self.indices.copy(), self.indptr.copy()), shape=self.shape)
+        return csc_matrix((self.data, self.indices.copy(), self.indptr.copy()), shape=self.shape)
 
     def tocsc(self, copy: bool = True) -> csc_matrix:
         """Materialize the logical matrix as a SciPy CSC matrix.
@@ -200,3 +218,9 @@ class OneSparseMatrix:
 
     def __rsub__(self, other):
         return other - self.to_csc()
+
+    def __matmul__(self, other):
+        return self.to_csc() @ other
+
+    def __rmatmul__(self, other):
+        return other @ self.to_csc()

--- a/src/linear_dag/core/one_sparse.py
+++ b/src/linear_dag/core/one_sparse.py
@@ -131,6 +131,51 @@ class OneSparseMatrix:
         data[self.nonunit_edge_indices] = self.nonunit_values
         return csc_matrix((data, self.indices.copy(), self.indptr.copy()), shape=self.shape)
 
+    def tocsc(self, copy: bool = True) -> csc_matrix:
+        """Materialize the logical matrix as a SciPy CSC matrix.
+
+        This compatibility adapter mirrors the common SciPy sparse-matrix
+        method name. Materialization necessarily allocates the full edge-weight
+        array; callers should therefore keep the result local to operations
+        that require SciPy's sparse-matrix API.
+
+        **Arguments:**
+
+        - `copy`: Accepted for compatibility. The returned matrix is always
+          independent because its dense edge-weight array must be constructed.
+
+        **Returns:**
+
+        - Equivalent SciPy `csc_matrix`.
+        """
+        return self.to_csc()
+
+    def tocsr(self, copy: bool = True):
+        """Materialize the logical matrix as a SciPy CSR matrix.
+
+        **Arguments:**
+
+        - `copy`: Accepted for compatibility.
+
+        **Returns:**
+
+        - Equivalent SciPy `csr_matrix`.
+        """
+        return self.to_csc().tocsr(copy=copy)
+
+    def tocoo(self, copy: bool = True):
+        """Materialize the logical matrix as a SciPy COO matrix.
+
+        **Arguments:**
+
+        - `copy`: Accepted for compatibility.
+
+        **Returns:**
+
+        - Equivalent SciPy `coo_matrix`.
+        """
+        return self.to_csc().tocoo(copy=copy)
+
     def copy(self) -> "OneSparseMatrix":
         """Return a deep copy of this matrix.
 

--- a/src/linear_dag/core/parallel_processing.py
+++ b/src/linear_dag/core/parallel_processing.py
@@ -298,6 +298,9 @@ class ParallelOperator(LinearOperator):
     iids: Optional[pl.Series] = None
     _variant_view_handles: List[_SharedArrayHandle] = field(default_factory=list)
 
+    def __post_init__(self) -> None:
+        LinearOperator.__init__(self, dtype=self.dtype, shape=self.shape)
+
     def __enter__(self):
         self._manager.__enter__()
         return self
@@ -717,6 +720,9 @@ class GRMOperator(LinearOperator):
     shape: tuple[int, int]
     dtype: np.dtype = np.float32
     iids: Optional[pl.Series] = None
+
+    def __post_init__(self) -> None:
+        LinearOperator.__init__(self, dtype=self.dtype, shape=self.shape)
 
     def __enter__(self):
         self._manager.__enter__()

--- a/src/linear_dag/core/solve.pyx
+++ b/src/linear_dag/core/solve.pyx
@@ -48,6 +48,53 @@ def spsolve_backward_triangular(A: "csc_matrix", b: np.ndarray) -> None:
                 b_view[node_idx] += b_view[indices[edge_idx]] * data[edge_idx]
 
 
+def spsolve_forward_triangular_one_sparse(A, b: np.ndarray) -> None:
+    """Solve ``(I-A)x = b`` in place for a default-one compressed matrix."""
+    cdef int[:] indptr = A.indptr
+    cdef int[:] indices = A.indices
+    cdef int[:] nonunit_indices = A.nonunit_edge_indices
+    cdef int[:] nonunit_values = A.nonunit_values
+    cdef double[:] b_view = b
+    cdef int num_nodes = len(indptr) - 1
+    cdef int node_idx, special_edge_idx, edge_idx = 0
+    cdef int nonunit_idx = 0
+    cdef int num_nonunit = len(nonunit_indices)
+    cdef double source
+
+    with nogil:
+        for node_idx in range(num_nodes):
+            source = b_view[node_idx]
+            while edge_idx < indptr[node_idx + 1]:
+                b_view[indices[edge_idx]] += source
+                edge_idx += 1
+            while nonunit_idx < num_nonunit and nonunit_indices[nonunit_idx] < indptr[node_idx + 1]:
+                special_edge_idx = nonunit_indices[nonunit_idx]
+                b_view[indices[special_edge_idx]] += (<double> nonunit_values[nonunit_idx] - 1.0) * source
+                nonunit_idx += 1
+
+
+def spsolve_backward_triangular_one_sparse(A, b: np.ndarray) -> None:
+    """Solve ``(I-A)'x = b`` in place for a default-one compressed matrix."""
+    cdef int[:] indptr = A.indptr
+    cdef int[:] indices = A.indices
+    cdef int[:] nonunit_indices = A.nonunit_edge_indices
+    cdef int[:] nonunit_values = A.nonunit_values
+    cdef double[:] b_view = b
+    cdef int num_nodes = len(indptr) - 1
+    cdef int node_idx, special_edge_idx, edge_idx = indptr[num_nodes]
+    cdef int nonunit_idx = len(nonunit_indices) - 1
+
+    with nogil:
+        for node_idx in range(num_nodes - 1, -1, -1):
+            while edge_idx > indptr[node_idx]:
+                edge_idx -= 1
+                b_view[node_idx] += b_view[indices[edge_idx]]
+            while nonunit_idx >= 0 and nonunit_indices[nonunit_idx] >= indptr[node_idx]:
+                special_edge_idx = nonunit_indices[nonunit_idx]
+                b_view[node_idx] += (<double> nonunit_values[nonunit_idx] - 1.0) * b_view[indices[special_edge_idx]]
+                nonunit_idx -= 1
+
+
 def spsolve_forward_triangular_matmat(A: "csc_matrix", b: np.ndarray, nonunique_indices: np.ndarray, min_index_to_keep: int) -> None:
     """Solves (I-A)x' = b' in place, where A is a lower-triangular, zero-diagonal CSC matrix.
     Assumes that b is Fortran-contiguous. nonunique_indices is an array of length equal to A.shape[0] that
@@ -259,6 +306,214 @@ cdef void _spsolve_backward_triangular_matmat_float32(
 
             # Call the BLAS axpy routine for destination += alpha * source
             blas.saxpy(vector_length_ptr, alpha_ptr, source_ptr, inc_ptr, destination_ptr, inc_ptr)
+
+
+def spsolve_forward_triangular_matmat_one_sparse(
+    A, b: np.ndarray, nonunique_indices: np.ndarray, min_index_to_keep: int
+) -> None:
+    """Solve ``(I-A)x' = b'`` in place for a default-one compressed matrix."""
+    if b.ndim == 1:
+        b = b.reshape(1, -1)
+    if b.dtype == np.float64:
+        _spsolve_forward_triangular_matmat_one_sparse_float64(
+            A.indptr, A.indices, A.nonunit_edge_indices, A.nonunit_values,
+            b, nonunique_indices, min_index_to_keep
+        )
+    elif b.dtype == np.float32:
+        _spsolve_forward_triangular_matmat_one_sparse_float32(
+            A.indptr, A.indices, A.nonunit_edge_indices, A.nonunit_values,
+            b, nonunique_indices, min_index_to_keep
+        )
+    else:
+        b_copy = b.astype(np.float64)
+        _spsolve_forward_triangular_matmat_one_sparse_float64(
+            A.indptr, A.indices, A.nonunit_edge_indices, A.nonunit_values,
+            b_copy, nonunique_indices, min_index_to_keep
+        )
+        b[:] = b_copy
+
+
+cdef void _spsolve_forward_triangular_matmat_one_sparse_float64(
+    int[:] indptr, int[:] indices, int[:] nonunit_indices, int[:] nonunit_values,
+    double[:, :] b_view, int[:] nonunique_indices, int min_index_to_keep
+) noexcept nogil:
+    cdef int node_idx, edge_idx = 0
+    cdef int stop_edge_idx
+    cdef int nonunit_idx = 0
+    cdef int num_nodes = len(indptr) - 1
+    cdef int num_nonunit = len(nonunit_indices)
+    cdef int vector_length = b_view.shape[0]
+    cdef int vector_bytes = vector_length * sizeof(double)
+    cdef int inc = 1
+    cdef double alpha = 1.0
+    cdef double* source_ptr
+    cdef double* destination_ptr
+
+    for node_idx in range(num_nodes):
+        if edge_idx == indptr[node_idx + 1]:
+            continue
+        source_ptr = &b_view[0, nonunique_indices[node_idx]]
+        while edge_idx < indptr[node_idx + 1]:
+            if nonunit_idx < num_nonunit and nonunit_indices[nonunit_idx] < indptr[node_idx + 1]:
+                stop_edge_idx = nonunit_indices[nonunit_idx]
+            else:
+                stop_edge_idx = indptr[node_idx + 1]
+            alpha = 1.0
+            while edge_idx < stop_edge_idx:
+                destination_ptr = &b_view[0, nonunique_indices[indices[edge_idx]]]
+                blas.daxpy(&vector_length, &alpha, source_ptr, &inc, destination_ptr, &inc)
+                edge_idx += 1
+            if edge_idx < indptr[node_idx + 1]:
+                alpha = <double> nonunit_values[nonunit_idx]
+                destination_ptr = &b_view[0, nonunique_indices[indices[edge_idx]]]
+                blas.daxpy(&vector_length, &alpha, source_ptr, &inc, destination_ptr, &inc)
+                edge_idx += 1
+                nonunit_idx += 1
+        if node_idx < min_index_to_keep:
+            memset(source_ptr, 0, vector_bytes)
+
+
+cdef void _spsolve_forward_triangular_matmat_one_sparse_float32(
+    int[:] indptr, int[:] indices, int[:] nonunit_indices, int[:] nonunit_values,
+    float[:, :] b_view, int[:] nonunique_indices, int min_index_to_keep
+) noexcept nogil:
+    cdef int node_idx, edge_idx = 0
+    cdef int stop_edge_idx
+    cdef int nonunit_idx = 0
+    cdef int num_nodes = len(indptr) - 1
+    cdef int num_nonunit = len(nonunit_indices)
+    cdef int vector_length = b_view.shape[0]
+    cdef int vector_bytes = vector_length * sizeof(float)
+    cdef int inc = 1
+    cdef float alpha = 1.0
+    cdef float* source_ptr
+    cdef float* destination_ptr
+
+    for node_idx in range(num_nodes):
+        if edge_idx == indptr[node_idx + 1]:
+            continue
+        source_ptr = &b_view[0, nonunique_indices[node_idx]]
+        while edge_idx < indptr[node_idx + 1]:
+            if nonunit_idx < num_nonunit and nonunit_indices[nonunit_idx] < indptr[node_idx + 1]:
+                stop_edge_idx = nonunit_indices[nonunit_idx]
+            else:
+                stop_edge_idx = indptr[node_idx + 1]
+            alpha = 1.0
+            while edge_idx < stop_edge_idx:
+                destination_ptr = &b_view[0, nonunique_indices[indices[edge_idx]]]
+                blas.saxpy(&vector_length, &alpha, source_ptr, &inc, destination_ptr, &inc)
+                edge_idx += 1
+            if edge_idx < indptr[node_idx + 1]:
+                alpha = <float> nonunit_values[nonunit_idx]
+                destination_ptr = &b_view[0, nonunique_indices[indices[edge_idx]]]
+                blas.saxpy(&vector_length, &alpha, source_ptr, &inc, destination_ptr, &inc)
+                edge_idx += 1
+                nonunit_idx += 1
+        if node_idx < min_index_to_keep:
+            memset(source_ptr, 0, vector_bytes)
+
+
+def spsolve_backward_triangular_matmat_one_sparse(
+    A, b: np.ndarray, nonunique_indices: np.ndarray, min_index_to_keep: int
+) -> None:
+    """Solve ``(I-A)'x' = b'`` in place for a default-one compressed matrix."""
+    if b.ndim == 1:
+        b = b.reshape(1, -1)
+    if b.dtype == np.float64:
+        _spsolve_backward_triangular_matmat_one_sparse_float64(
+            A.indptr, A.indices, A.nonunit_edge_indices, A.nonunit_values,
+            b, nonunique_indices, min_index_to_keep
+        )
+    elif b.dtype == np.float32:
+        _spsolve_backward_triangular_matmat_one_sparse_float32(
+            A.indptr, A.indices, A.nonunit_edge_indices, A.nonunit_values,
+            b, nonunique_indices, min_index_to_keep
+        )
+    else:
+        b_copy = b.astype(np.float64)
+        _spsolve_backward_triangular_matmat_one_sparse_float64(
+            A.indptr, A.indices, A.nonunit_edge_indices, A.nonunit_values,
+            b_copy, nonunique_indices, min_index_to_keep
+        )
+        b[:] = b_copy
+
+
+cdef void _spsolve_backward_triangular_matmat_one_sparse_float64(
+    int[:] indptr, int[:] indices, int[:] nonunit_indices, int[:] nonunit_values,
+    double[:, :] b_view, int[:] nonunique_indices, int min_index_to_keep
+) noexcept nogil:
+    cdef int num_nodes = len(indptr) - 1
+    cdef int node_idx, edge_idx = indptr[num_nodes]
+    cdef int stop_edge_idx
+    cdef int nonunit_idx = len(nonunit_indices) - 1
+    cdef int vector_length = b_view.shape[0]
+    cdef int vector_bytes = vector_length * sizeof(double)
+    cdef int inc = 1
+    cdef double alpha = 1.0
+    cdef double* source_ptr
+    cdef double* destination_ptr
+
+    for node_idx in range(num_nodes - 1, -1, -1):
+        if edge_idx == indptr[node_idx]:
+            continue
+        destination_ptr = &b_view[0, nonunique_indices[node_idx]]
+        if node_idx < min_index_to_keep:
+            memset(destination_ptr, 0, vector_bytes)
+        while edge_idx > indptr[node_idx]:
+            if nonunit_idx >= 0 and nonunit_indices[nonunit_idx] >= indptr[node_idx]:
+                stop_edge_idx = nonunit_indices[nonunit_idx]
+            else:
+                stop_edge_idx = indptr[node_idx] - 1
+            alpha = 1.0
+            while edge_idx - 1 > stop_edge_idx:
+                edge_idx -= 1
+                source_ptr = &b_view[0, nonunique_indices[indices[edge_idx]]]
+                blas.daxpy(&vector_length, &alpha, source_ptr, &inc, destination_ptr, &inc)
+            if edge_idx > indptr[node_idx]:
+                edge_idx -= 1
+                alpha = <double> nonunit_values[nonunit_idx]
+                source_ptr = &b_view[0, nonunique_indices[indices[edge_idx]]]
+                blas.daxpy(&vector_length, &alpha, source_ptr, &inc, destination_ptr, &inc)
+                nonunit_idx -= 1
+
+
+cdef void _spsolve_backward_triangular_matmat_one_sparse_float32(
+    int[:] indptr, int[:] indices, int[:] nonunit_indices, int[:] nonunit_values,
+    float[:, :] b_view, int[:] nonunique_indices, int min_index_to_keep
+) noexcept nogil:
+    cdef int num_nodes = len(indptr) - 1
+    cdef int node_idx, edge_idx = indptr[num_nodes]
+    cdef int stop_edge_idx
+    cdef int nonunit_idx = len(nonunit_indices) - 1
+    cdef int vector_length = b_view.shape[0]
+    cdef int vector_bytes = vector_length * sizeof(float)
+    cdef int inc = 1
+    cdef float alpha = 1.0
+    cdef float* source_ptr
+    cdef float* destination_ptr
+
+    for node_idx in range(num_nodes - 1, -1, -1):
+        if edge_idx == indptr[node_idx]:
+            continue
+        destination_ptr = &b_view[0, nonunique_indices[node_idx]]
+        if node_idx < min_index_to_keep:
+            memset(destination_ptr, 0, vector_bytes)
+        while edge_idx > indptr[node_idx]:
+            if nonunit_idx >= 0 and nonunit_indices[nonunit_idx] >= indptr[node_idx]:
+                stop_edge_idx = nonunit_indices[nonunit_idx]
+            else:
+                stop_edge_idx = indptr[node_idx] - 1
+            alpha = 1.0
+            while edge_idx - 1 > stop_edge_idx:
+                edge_idx -= 1
+                source_ptr = &b_view[0, nonunique_indices[indices[edge_idx]]]
+                blas.saxpy(&vector_length, &alpha, source_ptr, &inc, destination_ptr, &inc)
+            if edge_idx > indptr[node_idx]:
+                edge_idx -= 1
+                alpha = <float> nonunit_values[nonunit_idx]
+                source_ptr = &b_view[0, nonunique_indices[indices[edge_idx]]]
+                blas.saxpy(&vector_length, &alpha, source_ptr, &inc, destination_ptr, &inc)
+                nonunit_idx -= 1
         
 
 def add_at(destination: np.ndarray, 
@@ -611,8 +866,3 @@ cdef void _dfs(long node, Stack leaves_visited, long[:] indices, long[:] indptr,
         _dfs(neighbors[i], leaves_visited, indices, indptr, visited)
 
     
-
-
-
-
-

--- a/tests/core/test_one_sparse.py
+++ b/tests/core/test_one_sparse.py
@@ -1,6 +1,8 @@
 import h5py
 import numpy as np
 
+from scipy.sparse import csc_matrix
+
 from linear_dag import LinearARG, OneSparseMatrix
 from linear_dag.association.blup import blup
 
@@ -36,32 +38,38 @@ def test_compressed_lineararg_products_match_default(linarg_h5_path, first_block
     assert np.allclose(compressed._rmatmat(sample_matrix), default._rmatmat(sample_matrix))
 
 
-def test_default_hdf5_roundtrip_uses_compressed_schema(tmp_path, linarg_h5_path, first_block_name):
+def test_default_hdf5_roundtrip_uses_legacy_compatible_schema(tmp_path, linarg_h5_path, first_block_name):
     linarg = LinearARG.read(linarg_h5_path, block=first_block_name)
-    path = tmp_path / "compressed.h5"
+    path = tmp_path / "default.h5"
 
     linarg.write(path, save_allele_counts=False)
 
     with h5py.File(path, "r") as file:
-        assert "data" not in file
-        assert file.attrs["edge_weight_encoding"] == "one_sparse_v1"
-        assert "nonunit_edge_indices" in file
-        assert "nonunit_values" in file
+        assert "data" in file
+        assert "edge_weight_encoding" not in file.attrs
+        legacy_adjacency = csc_matrix(
+            (file["data"][:], file["indices"][:], file["indptr"][:]),
+            shape=(file.attrs["n"], file.attrs["n"]),
+        )
+
+    assert np.array_equal(legacy_adjacency.data, linarg.A.data)
 
     reloaded = LinearARG.read(path)
     assert isinstance(reloaded.A, OneSparseMatrix)
     assert np.array_equal(reloaded.A.to_csc().data, linarg.A.to_csc().data)
 
 
-def test_legacy_hdf5_write_remains_readable_as_compressed(tmp_path, linarg_h5_path, first_block_name):
+def test_explicit_compressed_hdf5_write_roundtrip(tmp_path, linarg_h5_path, first_block_name):
     linarg = LinearARG.read(linarg_h5_path, block=first_block_name)
-    path = tmp_path / "legacy.h5"
+    path = tmp_path / "compressed.h5"
 
-    linarg.write(path, save_allele_counts=False, compress_edge_weights=False)
+    linarg.write(path, save_allele_counts=False, compress_edge_weights=True)
 
     with h5py.File(path, "r") as file:
-        assert "data" in file
-        assert "edge_weight_encoding" not in file.attrs
+        assert "data" not in file
+        assert file.attrs["edge_weight_encoding"] == "one_sparse_v1"
+        assert "nonunit_edge_indices" in file
+        assert "nonunit_values" in file
 
     reloaded = LinearARG.read(path)
     assert isinstance(reloaded.A, OneSparseMatrix)
@@ -90,3 +98,13 @@ def test_blup_matches_scipy_adjacency_adapter(linarg_h5_path, first_block_name):
         rtol=1e-6,
         atol=1e-6,
     )
+
+
+def test_common_csc_read_operations_remain_available(linarg_h5_path, first_block_name):
+    linarg = LinearARG.read(linarg_h5_path, block=first_block_name)
+    adjacency = linarg.A.to_csc()
+    vector = np.random.default_rng(456).standard_normal(adjacency.shape[1])
+
+    assert np.array_equal(linarg.A.data, adjacency.data)
+    np.testing.assert_allclose(linarg.A @ vector, adjacency @ vector)
+    np.testing.assert_allclose(vector @ linarg.A, vector @ adjacency)

--- a/tests/core/test_one_sparse.py
+++ b/tests/core/test_one_sparse.py
@@ -1,0 +1,51 @@
+import h5py
+import numpy as np
+
+from linear_dag.core.lineararg import LinearARG
+from linear_dag.core.one_sparse import OneSparseMatrix
+
+
+def test_one_sparse_roundtrip_preserves_csc(linarg_h5_path, first_block_name):
+    linarg = LinearARG.read(linarg_h5_path, block=first_block_name)
+    compressed = OneSparseMatrix.from_csc(linarg.A)
+
+    restored = compressed.to_csc()
+
+    assert np.array_equal(restored.indptr, linarg.A.indptr)
+    assert np.array_equal(restored.indices, linarg.A.indices)
+    assert np.array_equal(restored.data, linarg.A.data)
+    assert compressed.edge_weight_nbytes < linarg.A.data.nbytes
+
+
+def test_compressed_lineararg_products_match_default(linarg_h5_path, first_block_name):
+    default = LinearARG.read(linarg_h5_path, block=first_block_name)
+    compressed = LinearARG.read(linarg_h5_path, block=first_block_name, compress_edge_weights=True)
+    rng = np.random.default_rng(42)
+
+    variant_vector = rng.standard_normal(default.shape[1])
+    sample_vector = rng.standard_normal(default.shape[0])
+    variant_matrix = rng.standard_normal((default.shape[1], 7)).astype(np.float32)
+    sample_matrix = rng.standard_normal((default.shape[0], 7)).astype(np.float32)
+
+    assert np.allclose(compressed._matvec(variant_vector), default._matvec(variant_vector))
+    assert np.allclose(compressed._rmatvec(sample_vector), default._rmatvec(sample_vector))
+    assert np.allclose(compressed._matmat(variant_matrix), default._matmat(variant_matrix))
+    assert np.allclose(compressed._rmatmat(sample_matrix), default._rmatmat(sample_matrix))
+
+
+def test_compressed_edge_weight_hdf5_roundtrip(tmp_path, linarg_h5_path, first_block_name):
+    linarg = LinearARG.read(linarg_h5_path, block=first_block_name)
+    path = tmp_path / "compressed.h5"
+
+    linarg.write(path, save_allele_counts=False, compress_edge_weights=True)
+
+    with h5py.File(path, "r") as file:
+        assert "data" not in file
+        assert file.attrs["edge_weight_encoding"] == "one_sparse_v1"
+        assert "nonunit_edge_indices" in file
+        assert "nonunit_values" in file
+
+    default_reload = LinearARG.read(path)
+    compressed_reload = LinearARG.read(path, compress_edge_weights=True)
+    assert np.array_equal(default_reload.A.data, linarg.A.data)
+    assert np.array_equal(compressed_reload.A.to_csc().data, linarg.A.data)

--- a/tests/core/test_one_sparse.py
+++ b/tests/core/test_one_sparse.py
@@ -1,25 +1,28 @@
 import h5py
 import numpy as np
 
-from linear_dag.core.lineararg import LinearARG
-from linear_dag.core.one_sparse import OneSparseMatrix
+from linear_dag import LinearARG, OneSparseMatrix
+from linear_dag.association.blup import blup
 
 
 def test_one_sparse_roundtrip_preserves_csc(linarg_h5_path, first_block_name):
     linarg = LinearARG.read(linarg_h5_path, block=first_block_name)
-    compressed = OneSparseMatrix.from_csc(linarg.A)
+    assert isinstance(linarg.A, OneSparseMatrix)
+    original = linarg.A.to_csc()
+    compressed = OneSparseMatrix.from_csc(original)
 
     restored = compressed.to_csc()
 
-    assert np.array_equal(restored.indptr, linarg.A.indptr)
-    assert np.array_equal(restored.indices, linarg.A.indices)
-    assert np.array_equal(restored.data, linarg.A.data)
-    assert compressed.edge_weight_nbytes < linarg.A.data.nbytes
+    assert np.array_equal(restored.indptr, original.indptr)
+    assert np.array_equal(restored.indices, original.indices)
+    assert np.array_equal(restored.data, original.data)
+    assert compressed.edge_weight_nbytes < original.data.nbytes
 
 
 def test_compressed_lineararg_products_match_default(linarg_h5_path, first_block_name):
-    default = LinearARG.read(linarg_h5_path, block=first_block_name)
     compressed = LinearARG.read(linarg_h5_path, block=first_block_name, compress_edge_weights=True)
+    default = compressed.copy()
+    default.A = compressed.A.to_csc()
     rng = np.random.default_rng(42)
 
     variant_vector = rng.standard_normal(default.shape[1])
@@ -33,11 +36,11 @@ def test_compressed_lineararg_products_match_default(linarg_h5_path, first_block
     assert np.allclose(compressed._rmatmat(sample_matrix), default._rmatmat(sample_matrix))
 
 
-def test_compressed_edge_weight_hdf5_roundtrip(tmp_path, linarg_h5_path, first_block_name):
+def test_default_hdf5_roundtrip_uses_compressed_schema(tmp_path, linarg_h5_path, first_block_name):
     linarg = LinearARG.read(linarg_h5_path, block=first_block_name)
     path = tmp_path / "compressed.h5"
 
-    linarg.write(path, save_allele_counts=False, compress_edge_weights=True)
+    linarg.write(path, save_allele_counts=False)
 
     with h5py.File(path, "r") as file:
         assert "data" not in file
@@ -45,7 +48,45 @@ def test_compressed_edge_weight_hdf5_roundtrip(tmp_path, linarg_h5_path, first_b
         assert "nonunit_edge_indices" in file
         assert "nonunit_values" in file
 
-    default_reload = LinearARG.read(path)
-    compressed_reload = LinearARG.read(path, compress_edge_weights=True)
-    assert np.array_equal(default_reload.A.data, linarg.A.data)
-    assert np.array_equal(compressed_reload.A.to_csc().data, linarg.A.data)
+    reloaded = LinearARG.read(path)
+    assert isinstance(reloaded.A, OneSparseMatrix)
+    assert np.array_equal(reloaded.A.to_csc().data, linarg.A.to_csc().data)
+
+
+def test_legacy_hdf5_write_remains_readable_as_compressed(tmp_path, linarg_h5_path, first_block_name):
+    linarg = LinearARG.read(linarg_h5_path, block=first_block_name)
+    path = tmp_path / "legacy.h5"
+
+    linarg.write(path, save_allele_counts=False, compress_edge_weights=False)
+
+    with h5py.File(path, "r") as file:
+        assert "data" in file
+        assert "edge_weight_encoding" not in file.attrs
+
+    reloaded = LinearARG.read(path)
+    assert isinstance(reloaded.A, OneSparseMatrix)
+    assert np.array_equal(reloaded.A.to_csc().data, linarg.A.to_csc().data)
+
+
+def test_scipy_boundary_operations_return_compressed_linearargs(linarg_h5_path, first_block_name):
+    linarg = LinearARG.read(linarg_h5_path, block=first_block_name)
+
+    removed = linarg.remove_samples([str(linarg.iids[0])])
+    with_individuals = linarg.add_individual_nodes()
+
+    assert isinstance(removed.A, OneSparseMatrix)
+    assert isinstance(with_individuals.A, OneSparseMatrix)
+
+
+def test_blup_matches_scipy_adjacency_adapter(linarg_h5_path, first_block_name):
+    compressed = LinearARG.read(linarg_h5_path, block=first_block_name)
+    scipy_backed = compressed.copy()
+    scipy_backed.A = compressed.A.to_csc()
+    phenotype = np.random.default_rng(123).standard_normal(compressed.shape[0])
+
+    np.testing.assert_allclose(
+        blup(compressed, 0.5, phenotype),
+        blup(scipy_backed, 0.5, phenotype),
+        rtol=1e-6,
+        atol=1e-6,
+    )

--- a/tests/core/test_parallel_processing.py
+++ b/tests/core/test_parallel_processing.py
@@ -189,6 +189,7 @@ def _rewrite_with_compressed_edge_weights(source: Path, destination: Path) -> No
                 "start": block_info["start"],
                 "end": block_info["end"],
             },
+            compress_edge_weights=True,
         )
 
 

--- a/tests/core/test_parallel_processing.py
+++ b/tests/core/test_parallel_processing.py
@@ -5,6 +5,7 @@ from inspect import signature
 from pathlib import Path
 from types import SimpleNamespace
 
+import h5py
 import numpy as np
 import pytest
 
@@ -176,6 +177,57 @@ def _load_serial_blocks(hdf5_path: Path):
     n_variants = blocks_df.get_column("n_variants").to_list()
     linargs = [LinearARG.read(hdf5_path, block) for block in block_names]
     return linargs, n_variants
+
+
+def _rewrite_with_compressed_edge_weights(source: Path, destination: Path) -> None:
+    for block_info in list_blocks(source).iter_rows(named=True):
+        linarg = LinearARG.read(source, block=block_info["block_name"], load_metadata=True)
+        linarg.write(
+            destination,
+            block_info={
+                "chrom": block_info["chrom"],
+                "start": block_info["start"],
+                "end": block_info["end"],
+            },
+        )
+
+
+def test_parallel_and_grm_operators_read_compressed_hdf5(tmp_path, linarg_h5_path: Path):
+    compressed_path = tmp_path / "compressed_blocks.h5"
+    _rewrite_with_compressed_edge_weights(linarg_h5_path, compressed_path)
+
+    with h5py.File(compressed_path, "r") as file:
+        for block_name in list_blocks(compressed_path).get_column("block_name"):
+            block = file[block_name]
+            assert block.attrs["edge_weight_encoding"] == "one_sparse_v1"
+            assert "data" not in block
+
+    linargs, nvars = _load_serial_blocks(compressed_path)
+    n = linargs[0].shape[0]
+    m = sum(nvars)
+    rng = np.random.default_rng(20260713)
+    variants = rng.standard_normal((m, 3)).astype(np.float32)
+    samples = rng.standard_normal((n, 3)).astype(np.float32)
+
+    serial_forward = np.zeros((n, 3), dtype=np.float32)
+    offset = 0
+    for linarg, num_variants in zip(linargs, nvars):
+        serial_forward += linarg @ variants[offset : offset + num_variants]
+        offset += num_variants
+    serial_reverse = np.vstack([linarg.T @ samples for linarg in linargs])
+
+    with ParallelOperator.from_hdf5(compressed_path, num_processes=2) as parallel:
+        np.testing.assert_allclose(parallel @ variants, serial_forward, rtol=1e-3, atol=1e-3)
+        np.testing.assert_allclose(parallel.T @ samples, serial_reverse, rtol=1e-5, atol=1e-5)
+
+    with GRMOperator.from_hdf5(compressed_path, num_processes=2) as grm:
+        grm_result = grm @ samples
+
+    serial_grm = np.zeros_like(samples)
+    for linarg in linargs:
+        normalized = linarg.normalized
+        serial_grm += normalized @ normalized.T @ samples
+    np.testing.assert_allclose(grm_result, serial_grm, rtol=1e-4, atol=1e-4)
 
 
 def test_matmat_matches_serial(linarg_h5_path: Path):


### PR DESCRIPTION
Improve linear ARG memory footprint by avoiding storing a vector of edge weights whose entries are mostly 1’s.

## Summary
- make `OneSparseMatrix` the canonical in-memory adjacency representation for all `LinearARG` construction and HDF5 loading paths; this stores the data array by recording non-1 entries
- transparently load both legacy and `one_sparse_v1` HDF5 into compressed memory
- preserve the legacy `data` schema as the default writer for compatibility with existing releases; compressed on-disk encoding is explicit with `compress_edge_weights=True`
- preserve SciPy-dependent features through local CSC adapters, including sample removal, individual-node construction, carrier extraction, BLUP, and sample addition
- retain common adjacency reads and multiplication through `.data`, `A @ x`, `x @ A`, and explicit `tocsc`/`tocsr`/`tocoo` adapters
- export `OneSparseMatrix` publicly and document representation and benchmark tradeoffs

## Benchmarks
With 1000 Genomes data, matvec and matmat have similar or slightly faster runtime

## Compatibility
- Existing HDF5 files load directly into compressed in-memory structures.
- Default-written HDF5 retains `data` and can be read by previous releases.
- Explicit `one_sparse_v1` files are read by upgraded code.
- `LinearARG.A` is intentionally now a `OneSparseMatrix`; callers needing a mutable SciPy matrix should use `linarg.A.to_csc()`.

## Validation
- `.venv/bin/pytest tests -q` — 173 passed
- `.venv/bin/pytest tests/core/test_one_sparse.py tests/core/test_parallel_processing.py -q` — 31 passed
- fresh-context review completed; default-writer compatibility and common adjacency operations were strengthened in response
- `git diff --check`
- Python compile checks for changed modules and tests